### PR TITLE
Form simplification

### DIFF
--- a/codegen/templates/page/form/editform.tmpl
+++ b/codegen/templates/page/form/editform.tmpl
@@ -53,14 +53,8 @@ type {{= formName }} struct {
     control.FormBase
 }
 
-func New{{= formName }}(ctx context.Context) page.FormI {
-    f := new({{= formName }})
-    f.Init(ctx, f, {{= title }}EditPath, {{= title }}EditID)
-    return f
-}
-
-func (f *{{= formName }})Init(ctx context.Context, self page.FormI, path string, id string) {
-    f.FormBase.Init(ctx, self, path, id)
+func (f *{{= formName }})Init(ctx context.Context, id string) {
+    f.FormBase.Init(ctx, id)
 
 	f.AddRelatedFiles()
 	f.createControls(ctx)
@@ -154,8 +148,7 @@ func (f *{{= formName }}) returnToPrevious(ctx context.Context) {
 
 // init functions are called once when the web server first starts up.
 func init() {
-	page.RegisterPage({{= title }}EditPath,  New{{= formName }}, {{= title }}EditID)
-	page.RegisterControl({{= formName }}{})
+	page.RegisterForm({{= title }}EditPath,  &{{= formName }}{}, {{= title }}EditID)
 }
 
 

--- a/codegen/templates/page/form/listform.tmpl
+++ b/codegen/templates/page/form/listform.tmpl
@@ -37,14 +37,8 @@ type {{= formName }} struct {
     ListPanel    *panel.{{= t.GoName }}ListPanel
 }
 
-func New{{= formName }}(ctx context.Context) page.FormI {
-    f := new({{= formName }})
-    f.Init(ctx, f, {{= title }}ListPath, {{= title }}ListID)
-    return f
-}
-
-func (f *{{= formName }})Init(ctx context.Context, self page.FormI, path string, id string) {
-    f.FormBase.Init(ctx, self, path, id)
+func (f *{{= formName }})Init(ctx context.Context, id string) {
+    f.FormBase.Init(ctx, id)
 
 	f.AddRelatedFiles()
 	f.createControls(ctx)
@@ -86,8 +80,7 @@ func (f *{{= formName }}) LoadControls(ctx context.Context) {
 
 // init functions are called once when the web server first starts up.
 func init() {
-	page.RegisterPage({{= title }}ListPath,  New{{= formName }}, {{= title }}ListID)
-	page.RegisterControl({{= formName }}{})
+	page.RegisterForm({{= title }}ListPath,  &{{= formName }}{}, {{= title }}ListID)
 }
 
 

--- a/codegen/templates/page/form/listform.tmpl
+++ b/codegen/templates/page/form/listform.tmpl
@@ -34,7 +34,6 @@ const {{= title }}ListID = "{{= formName }}"
 // To edit it, make a copy and move it out of this package and into another
 type {{= formName }} struct {
     control.FormBase
-    ListPanel    *panel.{{= t.GoName }}ListPanel
 }
 
 func (f *{{= formName }})Init(ctx context.Context, id string) {

--- a/codegen/templates/page/panel/edit.tmpl
+++ b/codegen/templates/page/panel/edit.tmpl
@@ -24,12 +24,13 @@ type {{= panelName }} struct {
 
 func New{{= panelName }}(ctx context.Context, parent page.ControlI, id string) *{{= panelName}} {
     p := new({{= panelName }})
-	p.Init(ctx, p, parent, id)
+    p.Self = p
+	p.Init(ctx, parent, id)
 	return p
 }
 
-func (p *{{= panelName }}) Init(ctx context.Context, self page.ControlI, parent page.ControlI, id string) {
-	p.{{= panelName }}Base.Init(self, parent, id)
+func (p *{{= panelName }}) Init(ctx context.Context, parent page.ControlI, id string) {
+	p.{{= panelName }}Base.Init(parent, id)
 	p.CreateControls(ctx)
 }
 
@@ -98,6 +99,6 @@ func Get{{= panelName }}(c page.ControlI, id string) *{{= panelName }} {
 }
 
 func init() {
-    page.RegisterControl({{= panelName }}{})
+    page.RegisterControl(&{{= panelName }}{})
 }
 }}

--- a/codegen/templates/page/panel/list.tmpl
+++ b/codegen/templates/page/panel/list.tmpl
@@ -36,12 +36,13 @@ type {{= panelName }} struct {
 
 func New{{= panelName }}(ctx context.Context, parent page.ControlI, id string) *{{= panelName}} {
     p := new({{= panelName }})
-	p.Init(ctx, p, parent, id)
+    p.Self = p
+	p.Init(ctx, parent, id)
 	return p
 }
 
-func (p *{{= panelName }}) Init(ctx context.Context, self page.ControlI, parent page.ControlI, id string) {
-	p.{{= panelName }}Base.Init(self, parent, id)
+func (p *{{= panelName }}) Init(ctx context.Context, parent page.ControlI, id string) {
+	p.{{= panelName }}Base.Init(parent, id)
 	p.createControls(ctx)
 }
 
@@ -77,7 +78,7 @@ func Get{{= panelName }}(c page.ControlI, id string) *{{= panelName }} {
 }
 
 func init() {
-    page.RegisterControl({{= panelName }}{})
+    page.RegisterControl(&{{= panelName }}{})
 }
 
 }}

--- a/codegen/templates/page/panel/struct.tmpl
+++ b/codegen/templates/page/panel/struct.tmpl
@@ -18,10 +18,6 @@ type {{= panelName }} struct {
     {{= t.GoName }} *model.{{= t.GoName }}
 }
 
-func (p *{{= panelName }}) Init(self page.ControlI, parent page.ControlI, id string) {
-	p.Panel.Init(self, parent, id)
-}
-
 func (p *{{= panelName }}) this() {{= panelName }}I {
 	return p.Self.({{= panelName }}I)
 }

--- a/internal/install/goradd-project/control/form_base.go
+++ b/internal/install/goradd-project/control/form_base.go
@@ -2,7 +2,6 @@ package control
 
 import (
 	"context"
-	"github.com/goradd/goradd/pkg/page"
 	"github.com/goradd/goradd/pkg/page/control"
 )
 
@@ -12,8 +11,8 @@ type FormBase struct {
 	control.FormBase
 }
 
-func (f *FormBase) Init(ctx context.Context, self page.FormI, path string, id string) {
-	f.FormBase.Init(ctx, self, path, id)
+func (f *FormBase) Init(ctx context.Context, id string) {
+	f.FormBase.Init(ctx, id)
 
 	// additional initializations. For example, your custom page template.
 	//f.Page().SetDrawFunction()

--- a/internal/travis/goradd-test/main.go
+++ b/internal/travis/goradd-test/main.go
@@ -13,7 +13,7 @@ import (
 	// Below is where you import packages that register forms
 	_ "goradd-project/web/form" // Your  forms.
 
-	_ "github.com/goradd/goradd/pkg/bootstrap/examples" // Bootstrap examples
+	_ "github.com/goradd/goradd/pkg/bootstrap/examples/panels" // Bootstrap examples
 	_ "github.com/goradd/goradd/test/browsertest"
 	_ "github.com/goradd/goradd/web/examples/controls/panels"
 	_ "goradd-project/gen" // Code-generated forms

--- a/pkg/base/base.go
+++ b/pkg/base/base.go
@@ -13,7 +13,9 @@ type Base struct {
 }
 
 func (b *Base) Init(self interface{}) {
-	b.Self = self
+	if b.Self == nil {	// has it been setup manually earlier?
+		b.Self = self
+	}
 }
 
 func (b *Base) Type() string {

--- a/pkg/bootstrap/control/button.go
+++ b/pkg/bootstrap/control/button.go
@@ -61,12 +61,13 @@ const ButtonBlock = "btn-block"
 // Creates a new standard html button
 func NewButton(parent page.ControlI, id string) *Button {
 	b := &Button{}
-	b.Init(b, parent, id)
+	b.Self = b
+	b.Init(parent, id)
 	return b
 }
 
-func (b *Button) Init(self page.ControlI, parent page.ControlI, id string) {
-	b.Button.Init(self, parent, id)
+func (b *Button) Init(parent page.ControlI, id string) {
+	b.Button.Init(parent, id)
 	b.style = ButtonStyleSecondary // default
 	config.LoadBootstrap(b.ParentForm())
 }
@@ -195,5 +196,5 @@ func GetButton(c page.ControlI, id string) *Button {
 }
 
 func init() {
-	page.RegisterControl(Button{})
+	page.RegisterControl(&Button{})
 }

--- a/pkg/bootstrap/control/checkbox.go
+++ b/pkg/bootstrap/control/checkbox.go
@@ -15,7 +15,8 @@ type Checkbox struct {
 
 func NewCheckbox(parent page.ControlI, id string) *Checkbox {
 	c := &Checkbox{}
-	c.Init(c, parent, id)
+	c.Self = c
+	c.Init(parent, id)
 	config.LoadBootstrap(c.ParentForm())
 	return c
 }
@@ -123,5 +124,5 @@ func GetCheckbox(c page.ControlI, id string) *Checkbox {
 }
 
 func init() {
-	page.RegisterControl(Checkbox{})
+	page.RegisterControl(&Checkbox{})
 }

--- a/pkg/bootstrap/control/data_pager.go
+++ b/pkg/bootstrap/control/data_pager.go
@@ -25,12 +25,13 @@ type DataPager struct {
 
 func NewDataPager(parent page.ControlI, id string, pagedControl control.PagedControlI) *DataPager {
 	d := DataPager{}
-	d.Init(&d, parent, id, pagedControl)
+	d.Self = d
+	d.Init(parent, id, pagedControl)
 	return &d
 }
 
-func (d *DataPager) Init(self page.ControlI, parent page.ControlI, id string, pagedControl control.PagedControlI) {
-	d.DataPager.Init(self, parent, id, pagedControl)
+func (d *DataPager) Init(parent page.ControlI, id string, pagedControl control.PagedControlI) {
+	d.DataPager.Init(parent, id, pagedControl)
 	d.SetLabels(`<span aria-hidden="true">&laquo;</span><span class="sr-only">Previous</span>`,
 		`<span aria-hidden="true">&raquo;</span> <span class="sr-only">Next</span>`)
 	d.ButtonStyle = ButtonStyleOutlineSecondary
@@ -213,5 +214,5 @@ func (c DataPagerCreator) Init(ctx context.Context, ctrl DataPagerI) {
 }
 
 func init() {
-	page.RegisterControl(DataPager{})
+	page.RegisterControl(&DataPager{})
 }

--- a/pkg/bootstrap/control/form_fieldset.go
+++ b/pkg/bootstrap/control/form_fieldset.go
@@ -30,12 +30,13 @@ type FormFieldset struct {
 
 func NewFormFieldset(parent page.ControlI, id string) *FormFieldset {
 	p := &FormFieldset{}
-	p.Init(p, parent, id)
+	p.Self = p
+	p.Init(parent, id)
 	return p
 }
 
-func (c *FormFieldset) Init(self page.ControlI, parent page.ControlI, id string) {
-	c.Panel.Init(self, parent, id)
+func (c *FormFieldset) Init(parent page.ControlI, id string) {
+	c.Panel.Init(parent, id)
 	c.Tag = "fieldset"
 	c.legendAttributes = html.NewAttributes()
 	c.legendAttributes.AddClass("pt-0") // helps with alignment. Remove if needed
@@ -154,5 +155,5 @@ func GetFormFieldset(c page.ControlI, id string) *FormFieldset {
 }
 
 func init() {
-	page.RegisterControl(FormFieldset{})
+	page.RegisterControl(&FormFieldset{})
 }

--- a/pkg/bootstrap/control/form_group.go
+++ b/pkg/bootstrap/control/form_group.go
@@ -28,12 +28,13 @@ type FormGroup struct {
 
 func NewFormGroup(parent page.ControlI, id string) *FormGroup {
 	p := &FormGroup{}
-	p.Init(p, parent, id)
+	p.Self = p
+	p.Init(parent, id)
 	return p
 }
 
-func (c *FormGroup) Init(self control.FormFieldWrapperI, parent page.ControlI, id string) {
-	c.FormFieldWrapper.Init(self, parent, id)
+func (c *FormGroup) Init(parent page.ControlI, id string) {
+	c.FormFieldWrapper.Init(parent, id)
 	c.innerDivAttr = html.NewAttributes()
 	c.AddClass("form-group") // to get a wrapper without this, just remove it after initialization
 	c.InstructionAttributes().AddClass("form-text")
@@ -258,5 +259,5 @@ func GetFormGroup(c page.ControlI, id string) *FormGroup {
 }
 
 func init() {
-	page.RegisterControl(FormGroup{})
+	page.RegisterControl(&FormGroup{})
 }

--- a/pkg/bootstrap/control/list_checkbox.go
+++ b/pkg/bootstrap/control/list_checkbox.go
@@ -32,12 +32,13 @@ type CheckboxList struct {
 
 func NewCheckboxList(parent page.ControlI, id string) *CheckboxList {
 	l := &CheckboxList{}
-	l.Init(l, parent, id)
+	l.Self = l
+	l.Init(parent, id)
 	return l
 }
 
-func (l *CheckboxList) Init(self CheckboxListI, parent page.ControlI, id string) {
-	l.CheckboxList.Init(self, parent, id)
+func (l *CheckboxList) Init(parent page.ControlI, id string) {
+	l.CheckboxList.Init(parent, id)
 	l.SetLabelDrawingMode(html.LabelAfter)
 	l.SetRowClass("row")
 }
@@ -159,5 +160,5 @@ func GetCheckboxList(c page.ControlI, id string) *CheckboxList {
 }
 
 func init() {
-	page.RegisterControl(CheckboxList{})
+	page.RegisterControl(&CheckboxList{})
 }

--- a/pkg/bootstrap/control/list_group.go
+++ b/pkg/bootstrap/control/list_group.go
@@ -24,12 +24,13 @@ type ListGroup struct {
 
 func NewListGroup(parent page.ControlI, id string) *ListGroup {
 	l := &ListGroup{}
-	l.Init(l, parent, id)
+	l.Self = l
+	l.Init(parent, id)
 	return l
 }
 
-func (l *ListGroup) Init(self page.ControlI, parent page.ControlI, id string) {
-	l.UnorderedList.Init(self, parent, id)
+func (l *ListGroup) Init(parent page.ControlI, id string) {
+	l.UnorderedList.Init(parent, id)
 	l.Tag = "div"
 	l.SetItemTag("a") // default to anchor tags. Change it to something else if needed.
 	l.AddClass("list-group")
@@ -85,5 +86,5 @@ func GetListGroup(c page.ControlI, id string) *ListGroup {
 }
 
 func init() {
-	page.RegisterControl(ListGroup{})
+	page.RegisterControl(&ListGroup{})
 }

--- a/pkg/bootstrap/control/list_radio.go
+++ b/pkg/bootstrap/control/list_radio.go
@@ -24,12 +24,13 @@ type RadioList struct {
 
 func NewRadioList(parent page.ControlI, id string) *RadioList {
 	l := &RadioList{}
-	l.Init(l, parent, id)
+	l.Self = l
+	l.Init(parent, id)
 	return l
 }
 
-func (l *RadioList) Init(self RadioListI, parent page.ControlI, id string) {
-	l.RadioList.Init(self, parent, id)
+func (l *RadioList) Init(parent page.ControlI, id string) {
+	l.RadioList.Init(parent, id)
 	l.SetLabelDrawingMode(html.LabelAfter)
 	l.SetRowClass("row")
 }
@@ -124,5 +125,5 @@ func GetRadioList(c page.ControlI, id string) *RadioList {
 }
 
 func init() {
-	page.RegisterControl(RadioList{})
+	page.RegisterControl(&RadioList{})
 }

--- a/pkg/bootstrap/control/list_select.go
+++ b/pkg/bootstrap/control/list_select.go
@@ -18,12 +18,13 @@ type SelectList struct {
 
 func NewSelectList(parent page.ControlI, id string) *SelectList {
 	t := new(SelectList)
-	t.Init(t, parent, id)
+	t.Self = t
+	t.Init(parent, id)
 	return t
 }
 
-func (l *SelectList) Init(self page.ControlI, parent page.ControlI, id string) {
-	l.SelectList.Init(self, parent, id)
+func (l *SelectList) Init(parent page.ControlI, id string) {
+	l.SelectList.Init(parent, id)
 	config.LoadBootstrap(l.ParentForm())
 }
 
@@ -86,5 +87,5 @@ func GetSelectList(c page.ControlI, id string) *SelectList {
 }
 
 func init() {
-	page.RegisterControl(SelectList{})
+	page.RegisterControl(&SelectList{})
 }

--- a/pkg/bootstrap/control/modal.go
+++ b/pkg/bootstrap/control/modal.go
@@ -49,16 +49,17 @@ const (
 
 func NewModal(parent page.ControlI, id string) *Modal {
 	d := &Modal{}
-	d.Init(d, parent, id)
+	d.Self = d
+	d.Init(parent, id)
 	return d
 }
 
-func (d *Modal) Init(self page.ControlI, parent page.ControlI, id string) {
+func (d *Modal) Init(parent page.ControlI, id string) {
 	if id == "" {
 		panic("Modals must have an id")
 	}
 
-	d.Panel.Init(self, parent, id)
+	d.Panel.Init(parent, id)
 	d.Tag = "div"
 	d.SetShouldAutoRender(true)
 
@@ -83,15 +84,15 @@ func (d *Modal) this() ModalI {
 }
 
 func (d *Modal) SetTitle(t string) {
-	if d.titleBar.title != t {
-		d.titleBar.title = t
+	if d.titleBar.Title != t {
+		d.titleBar.Title = t
 		d.titleBar.Refresh()
 	}
 }
 
 func (d *Modal) SetHasCloseBox(h bool) {
-	if d.titleBar.hasCloseBox != h {
-		d.titleBar.hasCloseBox = h
+	if d.titleBar.HasCloseBox != h {
+		d.titleBar.HasCloseBox = h
 		d.titleBar.Refresh()
 	}
 }
@@ -121,7 +122,7 @@ func (d *Modal) SetBackdrop(b ModalBackdropType) {
 }
 
 func (d *Modal) Title() string {
-	return d.titleBar.title
+	return d.titleBar.Title
 }
 
 func (d *Modal) AddTitlebarClass(class string) {
@@ -299,19 +300,21 @@ func BootstrapAlert(form page.FormI, message string, buttons interface{}) contro
 
 type TitleBar struct {
 	control.Panel
-	hasCloseBox bool
-	title       string
+	HasCloseBox bool
+	Title       string
 }
 
 func NewTitleBar(parent page.ControlI, id string) *TitleBar {
 	d := &TitleBar{}
-	d.Panel.Init(d, parent, id)
+	d.Self = d
+	d.Panel.Init(parent, id)
 	return d
 }
 
 func init() {
 	control.SetAlertFunction(BootstrapAlert)
-	page.RegisterControl(Modal{})
+	page.RegisterControl(&Modal{})
+	page.RegisterControl(&TitleBar{})
 }
 
 type ModalButtonCreator struct {

--- a/pkg/bootstrap/control/modal.tpl.go
+++ b/pkg/bootstrap/control/modal.tpl.go
@@ -53,7 +53,7 @@ func (d *Modal) DrawTemplate(ctx context.Context, buf *bytes.Buffer) (err error)
 }
 
 func (d *TitleBar) DrawTemplate(ctx context.Context, buf *bytes.Buffer) (err error) {
-	if d.title != "" {
+	if d.Title != "" {
 
 		buf.WriteString(`     <h5 id="`)
 
@@ -61,13 +61,13 @@ func (d *TitleBar) DrawTemplate(ctx context.Context, buf *bytes.Buffer) (err err
 
 		buf.WriteString(`_title" class="modal-title">`)
 
-		buf.WriteString(d.title)
+		buf.WriteString(d.Title)
 
 		buf.WriteString(`</h5>
 `)
 
 	}
-	if d.hasCloseBox {
+	if d.HasCloseBox {
 
 		buf.WriteString(`    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
       <span aria-hidden="true">&times;</span>

--- a/pkg/bootstrap/control/navbar.go
+++ b/pkg/bootstrap/control/navbar.go
@@ -77,12 +77,13 @@ const (
 // NewNavbar returns a newly created Bootstrap Navbar object
 func NewNavbar(parent page.ControlI, id string) *Navbar {
 	b := &Navbar{}
-	b.Init(b, parent, id)
+	b.Self = b
+	b.Init(parent, id)
 	return b
 }
 
-func (b *Navbar) Init(self page.ControlI, parent page.ControlI, id string) {
-	b.ControlBase.Init(self, parent, id)
+func (b *Navbar) Init(parent page.ControlI, id string) {
+	b.ControlBase.Init(parent, id)
 	b.Tag = "nav"
 	b.style = NavbarDark // default
 	b.background = BackgroundColorDark
@@ -175,5 +176,5 @@ func GetNavbar(c page.ControlI, id string) *Navbar {
 }
 
 func init() {
-	page.RegisterControl(Navbar{})
+	page.RegisterControl(&Navbar{})
 }

--- a/pkg/bootstrap/control/navbar_list.go
+++ b/pkg/bootstrap/control/navbar_list.go
@@ -34,13 +34,14 @@ func NavbarSelectEvent() *page.Event {
 
 func NewNavbarList(parent page.ControlI, id string) *NavbarList {
 	t := &NavbarList{}
+	t.Self = t
 	t.ItemList = control.NewItemList(t)
-	t.Init(t, parent, id)
+	t.Init(parent, id)
 	return t
 }
 
-func (l *NavbarList) Init(self NavbarListI, parent page.ControlI, id string) {
-	l.ControlBase.Init(self, parent, id)
+func (l *NavbarList) Init(parent page.ControlI, id string) {
+	l.ControlBase.Init(parent, id)
 	l.Tag = "ul"
 	l.subItemTag = "li"
 
@@ -243,5 +244,5 @@ func GetNavbarList(c page.ControlI, id string) *NavbarList {
 }
 
 func init() {
-	page.RegisterControl(NavbarList{})
+	page.RegisterControl(&NavbarList{})
 }

--- a/pkg/bootstrap/control/radioButton.go
+++ b/pkg/bootstrap/control/radioButton.go
@@ -19,7 +19,8 @@ type RadioButton struct {
 
 func NewRadioButton(parent page.ControlI, id string) *RadioButton {
 	c := &RadioButton{}
-	c.Init(c, parent, id)
+	c.Self = c
+	c.Init(parent, id)
 	config.LoadBootstrap(c.ParentForm())
 	return c
 }
@@ -115,5 +116,5 @@ func GetRadioButton(c page.ControlI, id string) *RadioButton {
 }
 
 func init() {
-	page.RegisterControl(RadioButton{})
+	page.RegisterControl(&RadioButton{})
 }

--- a/pkg/bootstrap/control/tabs.go
+++ b/pkg/bootstrap/control/tabs.go
@@ -25,12 +25,13 @@ type Tabs struct {
 
 func NewTabs(parent page.ControlI, id string) *Tabs {
 	t := &Tabs{}
-	t.Init(t, parent, id)
+	t.Self = t
+	t.Init(parent, id)
 	return t
 }
 
-func (l *Tabs) Init(self page.ControlI, parent page.ControlI, id string) {
-	l.Panel.Init(self, parent, id)
+func (l *Tabs) Init(parent page.ControlI, id string) {
+	l.Panel.Init(parent, id)
 	l.On(event.Event("show.bs.tab"), action.SetControlValue(l.ID(), "selectedId", javascript.JsCode("event.target.id")))
 }
 
@@ -62,5 +63,5 @@ func GetTabs(c page.ControlI, id string) *Tabs {
 }
 
 func init() {
-	page.RegisterControl(Tabs{})
+	page.RegisterControl(&Tabs{})
 }

--- a/pkg/bootstrap/control/textbox.go
+++ b/pkg/bootstrap/control/textbox.go
@@ -17,7 +17,8 @@ type Textbox struct {
 
 func NewTextbox(parent page.ControlI, id string) *Textbox {
 	t := new(Textbox)
-	t.Init(t, parent, id)
+	t.Self = t
+	t.Init(parent, id)
 	return t
 }
 
@@ -28,7 +29,7 @@ func (t *Textbox) DrawingAttributes(ctx context.Context) html.Attributes {
 }
 
 func init() {
-	page.RegisterControl(Textbox{})
+	page.RegisterControl(&Textbox{})
 }
 
 // Use TextboxCreator to create a textbox. Pass it to AddControls of a control, or as a Child of

--- a/pkg/bootstrap/control/textbox_date.go
+++ b/pkg/bootstrap/control/textbox_date.go
@@ -17,7 +17,8 @@ type DateTextbox struct {
 
 func NewDateTextbox(parent page.ControlI, id string) *DateTextbox {
 	t := new(DateTextbox)
-	t.Init(t, parent, id)
+	t.Self = t
+	t.Init(parent, id)
 	return t
 }
 
@@ -92,5 +93,5 @@ func GetDateTextbox(c page.ControlI, id string) *DateTextbox {
 }
 
 func init() {
-	page.RegisterControl(DateTextbox{})
+	page.RegisterControl(&DateTextbox{})
 }

--- a/pkg/bootstrap/control/textbox_email.go
+++ b/pkg/bootstrap/control/textbox_email.go
@@ -17,7 +17,8 @@ type EmailTextbox struct {
 
 func NewEmailTextbox(parent page.ControlI, id string) *EmailTextbox {
 	t := new(EmailTextbox)
-	t.Init(t, parent, id)
+	t.Self = t
+	t.Init(parent, id)
 	return t
 }
 
@@ -93,5 +94,5 @@ func GetEmailTextbox(c page.ControlI, id string) *EmailTextbox {
 }
 
 func init() {
-	page.RegisterControl(EmailTextbox{})
+	page.RegisterControl(&EmailTextbox{})
 }

--- a/pkg/bootstrap/control/textbox_float.go
+++ b/pkg/bootstrap/control/textbox_float.go
@@ -17,7 +17,8 @@ type FloatTextbox struct {
 
 func NewFloatTextbox(parent page.ControlI, id string) *FloatTextbox {
 	t := new(FloatTextbox)
-	t.Init(t, parent, id)
+	t.Self = t
+	t.Init(parent, id)
 	return t
 }
 
@@ -105,5 +106,5 @@ func GetFloatTextbox(c page.ControlI, id string) *FloatTextbox {
 
 
 func init() {
-	page.RegisterControl(FloatTextbox{})
+	page.RegisterControl(&FloatTextbox{})
 }

--- a/pkg/bootstrap/control/textbox_integer.go
+++ b/pkg/bootstrap/control/textbox_integer.go
@@ -17,7 +17,8 @@ type IntegerTextbox struct {
 
 func NewIntegerTextbox(parent page.ControlI, id string) *IntegerTextbox {
 	t := new(IntegerTextbox)
-	t.Init(t, parent, id)
+	t.Self = t
+	t.Init(parent, id)
 	return t
 }
 
@@ -104,5 +105,5 @@ func GetIntegerTextbox(c page.ControlI, id string) *IntegerTextbox {
 }
 
 func init() {
-	page.RegisterControl(IntegerTextbox{})
+	page.RegisterControl(&IntegerTextbox{})
 }

--- a/pkg/bootstrap/examples/controls_form.go
+++ b/pkg/bootstrap/examples/controls_form.go
@@ -20,9 +20,9 @@ type ControlsForm struct {
 	FormBase
 }
 
-func NewControlsForm(ctx context.Context) page.FormI {
+func Init(ctx context.Context, formID string) {
 	f := &ControlsForm{}
-	f.Init(ctx, f, ControlsFormPath, ControlsFormId)
+	f.Init(ctx, ControlsFormId)
 	f.AddRelatedFiles()
 	f.AddControls(ctx,
 		bootstrap.NavbarCreator{
@@ -41,8 +41,6 @@ func NewControlsForm(ctx context.Context) page.FormI {
 			},
 		},
 	)
-
-	return f
 }
 
 func (f *ControlsForm) LoadControls(ctx context.Context) {
@@ -83,8 +81,7 @@ func (f *ControlsForm) BindData(ctx context.Context, s DataManagerI) {
 
 
 func init() {
-	page.RegisterPage(ControlsFormPath, NewControlsForm, ControlsFormId)
-	page.RegisterControl(ControlsForm{})
+	page.RegisterForm(ControlsFormPath, &ControlsForm{}, ControlsFormId)
 }
 
 

--- a/pkg/bootstrap/examples/controls_form.go
+++ b/pkg/bootstrap/examples/controls_form.go
@@ -20,9 +20,8 @@ type ControlsForm struct {
 	FormBase
 }
 
-func Init(ctx context.Context, formID string) {
-	f := &ControlsForm{}
-	f.Init(ctx, ControlsFormId)
+func (f *ControlsForm) Init(ctx context.Context, formID string) {
+	f.FormBase.Init(ctx, formID)
 	f.AddRelatedFiles()
 	f.AddControls(ctx,
 		bootstrap.NavbarCreator{

--- a/pkg/bootstrap/examples/panels/default.go
+++ b/pkg/bootstrap/examples/panels/default.go
@@ -14,13 +14,14 @@ type DefaultPanel struct {
 
 func NewDefaultPanel(ctx context.Context, parent page.ControlI) {
 	p := &DefaultPanel{}
-	p.Panel.Init(p, parent, "defaultPanel")
+	p.Self = p
+	p.Panel.Init(parent, "defaultPanel")
 	config.LoadBootstrap(p.ParentForm())
 }
 
 func init() {
 	examples.RegisterPanel("", "Home", NewDefaultPanel, 1)
-	page.RegisterControl(DefaultPanel{})
+	page.RegisterControl(&DefaultPanel{})
 
 	//browsertest.RegisterTestFunction("Plain Textbox", TestPlain)
 }

--- a/pkg/bootstrap/examples/panels/forms1.go
+++ b/pkg/bootstrap/examples/panels/forms1.go
@@ -27,7 +27,13 @@ type Forms1Panel struct {
 
 func NewForms1Panel(ctx context.Context, parent page.ControlI) {
 	p := &Forms1Panel{}
-	p.Panel.Init(p, parent, "textboxPanel")
+	p.Self = p
+	p.Init(ctx, parent, "textboxPanel")
+
+}
+
+func (p *Forms1Panel) Init(ctx context.Context, parent page.ControlI, id string) {
+	p.Panel.Init(parent, id)
 	p.Panel.AddControls(ctx,
 		FormGroupCreator{
 			Label:"Name",
@@ -85,9 +91,10 @@ func NewForms1Panel(ctx context.Context, parent page.ControlI) {
 	)
 }
 
+
 func init() {
 	examples.RegisterPanel("forms1", "Forms 1", NewForms1Panel, 2)
-	page.RegisterControl(Forms1Panel{})
+	page.RegisterControl(&Forms1Panel{})
 	//browsertest.RegisterTestFunction("Bootstrap Standard Form Ajax Submit", testForms1AjaxSubmit)
 	//browsertest.RegisterTestFunction("Bootstrap Standard Form Server Submit", testForms1ServerSubmit)
 }

--- a/pkg/bootstrap/examples/panels/selectlist.go
+++ b/pkg/bootstrap/examples/panels/selectlist.go
@@ -17,6 +17,13 @@ type SelectListPanel struct {
 }
 
 func NewSelectListPanel(ctx context.Context, parent page.ControlI) {
+	p := &SelectListPanel{}
+	p.Self = p
+	p.Init(ctx, parent, "selectListPanel")
+
+}
+
+func (p *SelectListPanel) Init(ctx context.Context, parent page.ControlI, id string) {
 	itemList := []control.ListValue{
 		{"First", 1},
 		{"Second", 2},
@@ -27,9 +34,7 @@ func NewSelectListPanel(ctx context.Context, parent page.ControlI) {
 		{"Seventh", 7},
 		{"Eighth", 8},
 	}
-
-	p := &SelectListPanel{}
-	p.Panel.Init(p, parent, "selectListPanel")
+	p.Panel.Init(parent, id)
 
 	p.AddControls(ctx,
 		FormGroupCreator{
@@ -81,6 +86,7 @@ func NewSelectListPanel(ctx context.Context, parent page.ControlI) {
 		},
 
 	)
+
 
 }
 
@@ -143,7 +149,7 @@ func testSelectListSubmit(t *browsertest.TestForm, btnID string) {
 
 func init() {
 	examples.RegisterPanel("lists", "Lists", NewSelectListPanel, 3)
-	page.RegisterControl(SelectListPanel{})
+	page.RegisterControl(&SelectListPanel{})
 
 	browsertest.RegisterTestFunction("Bootstrap Select List Ajax Submit", testSelectListAjaxSubmit)
 	browsertest.RegisterTestFunction("Bootstrap Select List Server Submit", testSelectListServerSubmit)

--- a/pkg/bootstrap/examples/panels/table.go
+++ b/pkg/bootstrap/examples/panels/table.go
@@ -72,12 +72,17 @@ var tableSliceData = []TableSliceData{
 
 func NewTablePanel(ctx context.Context, parent page.ControlI) {
 	p := &TablePanel{}
-	p.Panel.Init(p, parent, "tablePanel")
-	p.AddControls(ctx,
+	p.Self = p
+	p.Init(ctx, parent, "tablePanel")
+}
+
+func (f *TablePanel) Init(ctx context.Context, parent page.ControlI, id string) {
+	f.Panel.Init(parent, id)
+	f.AddControls(ctx,
 		control.PagedTableCreator{
 			ID: "table1",
 			HeaderRowCount: 1,
-			DataProvider: p,
+			DataProvider: f,
 			Columns:[]control.ColumnCreator {
 				column.TexterColumnCreator{
 					Texter: "tablePanel",
@@ -132,5 +137,5 @@ func (f *TablePanel) CellText(ctx context.Context, col control.ColumnI, rowNum i
 
 func init() {
 	examples.RegisterPanel("table", "Tables", NewTablePanel, 5)
-	page.RegisterControl(TablePanel{})
+	page.RegisterControl(&TablePanel{})
 }

--- a/pkg/messageServer/ws/messenger.go
+++ b/pkg/messageServer/ws/messenger.go
@@ -97,7 +97,7 @@ func (m *WsMessenger) webSocketAuthHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		pagestate := r.FormValue("id")
 
-		if !page.GetPageManager().HasPage(pagestate) {
+		if !page.HasPage(pagestate) {
 			// The page manager has no record of the pagestate, so either it is expired or never existed
 			return // TODO: return error?
 		}

--- a/pkg/page/control.go
+++ b/pkg/page/control.go
@@ -353,14 +353,13 @@ type ControlBase struct {
 // call this superclass function. This Init function sets up a parent-child relationship with the given parent
 // control, and sets up data structures to use the control in object-oriented ways with virtual functions.
 // The id is the control id that will appear as the id in html. Leave blank for the system to create a unique id for you.
-func (c *ControlBase) Init(self ControlI, parent ControlI, id string) {
-	c.Base.Init(self)
+func (c *ControlBase) Init(parent ControlI, id string) {
 	c.attributes = html.NewAttributes()
 	if parent != nil {
 		c.page = parent.Page()
 		c.id = c.page.GenerateControlID(id)
 	}
-	self.SetParent(parent)
+	c.this().SetParent(parent)
 	c.isModified = true
 }
 

--- a/pkg/page/control/button.go
+++ b/pkg/page/control/button.go
@@ -34,13 +34,14 @@ type Button struct {
 // NewButton creates a new standard html button
 func NewButton(parent page.ControlI, id string) *Button {
 	b := &Button{}
-	b.Init(b, parent, id)
+	b.Self = b
+	b.Init(parent, id)
 	return b
 }
 
 // Init is called by subclasses of Button to initialize the button control structure.
-func (b *Button) Init(self page.ControlI, parent page.ControlI, id string) {
-	b.ControlBase.Init(self, parent, id)
+func (b *Button) Init(parent page.ControlI, id string) {
+	b.ControlBase.Init(parent, id)
 	b.Tag = "button"
 	b.SetValidationType(page.ValidateForm) // default to validate the entire form. Can be changed after creation.
 }
@@ -134,5 +135,5 @@ func GetButton(c page.ControlI, id string) *Button {
 }
 
 func init() {
-	page.RegisterControl(Button{})
+	page.RegisterControl(&Button{})
 }

--- a/pkg/page/control/canvas.go
+++ b/pkg/page/control/canvas.go
@@ -19,13 +19,14 @@ type Canvas struct {
 // NewCanvas creates a Canvas control
 func NewCanvas(parent page.ControlI, id string) *Canvas {
 	p := &Canvas{}
-	p.Init(p, parent, id)
+	p.Self = p
+	p.Init(parent, id)
 	return p
 }
 
 // Init is called by subcontrols. You do not normally need to call it.
-func (c *Canvas) Init(self CanvasI, parent page.ControlI, id string) {
-	c.ControlBase.Init(self, parent, id)
+func (c *Canvas) Init(parent page.ControlI, id string) {
+	c.ControlBase.Init(parent, id)
 	c.Tag = "canvas"
 }
 
@@ -58,5 +59,5 @@ func GetCanvas(c page.ControlI, id string) *Canvas {
 }
 
 func init() {
-	page.RegisterControl(Canvas{})
+	page.RegisterControl(&Canvas{})
 }

--- a/pkg/page/control/checkbox.go
+++ b/pkg/page/control/checkbox.go
@@ -14,7 +14,8 @@ type Checkbox struct {
 // NewCheckbox creates a new checkbox control.
 func NewCheckbox(parent page.ControlI, id string) *Checkbox {
 	c := &Checkbox{}
-	c.Init(c, parent, id)
+	c.Self = c
+	c.CheckboxBase.Init(parent, id)
 	return c
 }
 
@@ -80,5 +81,5 @@ func GetCheckbox(c page.ControlI, id string) *Checkbox {
 }
 
 func init() {
-	page.RegisterControl(Checkbox{})
+	page.RegisterControl(&Checkbox{})
 }

--- a/pkg/page/control/checkbox_base.go
+++ b/pkg/page/control/checkbox_base.go
@@ -25,8 +25,8 @@ type CheckboxBase struct {
 }
 
 // Init initializes a checkbox base class. It is called by checkbox implementations.
-func (c *CheckboxBase) Init(self page.ControlI, parent page.ControlI, id string) {
-	c.ControlBase.Init(self, parent, id)
+func (c *CheckboxBase) Init(parent page.ControlI, id string) {
+	c.ControlBase.Init(parent, id)
 
 	c.Tag = "input"
 	c.IsVoidTag = true

--- a/pkg/page/control/data_pager.go
+++ b/pkg/page/control/data_pager.go
@@ -207,20 +207,21 @@ type DataPager struct {
 
 // NewDataPager creates a new DataPager
 func NewDataPager(parent page.ControlI, id string, pagedControl PagedControlI) *DataPager {
-	d := DataPager{}
-	d.Init(&d, parent, id, pagedControl)
-	return &d
+	d := &DataPager{}
+	d.Self = d
+	d.Init(parent, id, pagedControl)
+	return d
 }
 
 // Init is called by subclasses of a DataPager to initialize the data pager. You do not normally need
 // to call this.
-func (d *DataPager) Init(self page.ControlI, parent page.ControlI, id string, pagedControl PagedControlI) {
-	d.ControlBase.Init(self, parent, id)
+func (d *DataPager) Init(parent page.ControlI, id string, pagedControl PagedControlI) {
+	d.ControlBase.Init(parent, id)
 	d.Tag = "div"
 	d.LabelForNext = d.GT("Next")
 	d.LabelForPrevious = d.GT("Previous")
 	d.maxPageButtons = DefaultMaxPagerButtons
-	pagedControl.AddDataPager(self.(DataPagerI))
+	pagedControl.AddDataPager(d.Self.(DataPagerI))
 	d.pagedControlID = pagedControl.ID()
 	pxy := NewProxy(d, d.proxyID())
 	pxy.On(event.Click().Bubbles(), action.Ajax(d.ID(), PageClick))
@@ -619,5 +620,5 @@ func (c DataPagerCreator) Init(ctx context.Context, ctrl DataPagerI) {
 }
 
 func init() {
-	page.RegisterControl(DataPager{})
+	page.RegisterControl(&DataPager{})
 }

--- a/pkg/page/control/datetime_span.go
+++ b/pkg/page/control/datetime_span.go
@@ -20,13 +20,14 @@ type DateTimeSpan struct {
 // NewDateTimeSpan create a new DateTimeSpan.
 func NewDateTimeSpan(parent page.ControlI, id string) *DateTimeSpan {
 	s := new(DateTimeSpan)
-	s.Init(s, parent, id)
+	s.Self = s
+	s.Init(parent, id)
 	return s
 }
 
 // Init is called by subclasses to initialize the parent. You do not normally need to call this.
-func (s *DateTimeSpan) Init(self page.ControlI, parent page.ControlI, id string) {
-	s.Span.Init(self, parent, id)
+func (s *DateTimeSpan) Init(parent page.ControlI, id string) {
+	s.Span.Init(parent, id)
 	s.format = config.DefaultDateTimeFormat
 }
 
@@ -129,5 +130,5 @@ func (c DateTimeSpanCreator) Create(ctx context.Context, parent page.ControlI) p
 }
 
 func init() {
-	page.RegisterControl(DateTimeSpan{})
+	page.RegisterControl(&DateTimeSpan{})
 }

--- a/pkg/page/control/dialog.go
+++ b/pkg/page/control/dialog.go
@@ -90,13 +90,13 @@ type DialogButtonOptions struct {
 // NewDialog creates a new dialog.
 func NewDialog(parent page.ControlI, id string) *Dialog {
 	d := &Dialog{}
-
-	d.Init(d, parent, id) // parent is always the form
+	d.Self = d
+	d.Init(parent, id) // parent is always the form
 	return d
 }
 
 // Init is called by subclasses of the dialog.
-func (d *Dialog) Init(self DialogI, parent page.ControlI, id string) {
+func (d *Dialog) Init(parent page.ControlI, id string) {
 	// Our strategy here is to create a dialog overlay that is a container for the currently shown dialogs. This
 	// container is owned by the form itself, even if sub-controls create the dialog.
 	var overlay page.ControlI
@@ -113,7 +113,7 @@ func (d *Dialog) Init(self DialogI, parent page.ControlI, id string) {
 	}
 
 	// Make the overlay our parent
-	d.Panel.Init(self, overlay, id)
+	d.Panel.Init(overlay, id)
 	d.Tag = "div"
 
 	d.titleBarID = d.ID()+"-title"
@@ -434,5 +434,5 @@ func SetAlertFunction(f AlertFuncType) {
 
 
 func init() {
-	page.RegisterControl(Dialog{})
+	page.RegisterControl(&Dialog{})
 }

--- a/pkg/page/control/fieldset.go
+++ b/pkg/page/control/fieldset.go
@@ -21,13 +21,14 @@ type Fieldset struct {
 // NewFieldset creates a new Fieldset.
 func NewFieldset(parent page.ControlI, id string) *Fieldset {
 	p := &Fieldset{}
-	p.Init(p, parent, id)
+	p.Self = p
+	p.Init(parent, id)
 	return p
 }
 
 // Init is called by subclasses of Fieldset.
-func (c *Fieldset) Init(self FieldsetI, parent page.ControlI, id string) {
-	c.Panel.Init(self, parent, id)
+func (c *Fieldset) Init(parent page.ControlI, id string) {
+	c.Panel.Init(parent, id)
 	c.Tag = "fieldset"
 }
 
@@ -90,5 +91,5 @@ func GetFieldset(c page.ControlI, id string) *Fieldset {
 }
 
 func init() {
-	page.RegisterControl(Fieldset{})
+	page.RegisterControl(&Fieldset{})
 }

--- a/pkg/page/control/form_base.go
+++ b/pkg/page/control/form_base.go
@@ -24,22 +24,23 @@ type MockForm struct {
 }
 
 func init() {
-	page.RegisterControl(MockForm{})
+	page.RegisterControl(&MockForm{})
 }
 
 // NewMockForm creates a form that should be used as a parent of a control when unit testing the control.
 func NewMockForm() *MockForm {
 	f := &MockForm{}
-	f.FormBase.Init(nil, f, "", "MockFormId")
+	f.Self = f
+	f.FormBase.Init(nil, "MockFormId")
 	return f
 }
 
 // Init initializes the FormBase. Call this before adding other controls.
-func (f *FormBase) Init(ctx context.Context, self page.FormI, path string, id string) {
+func (f *FormBase) Init(ctx context.Context, id string) {
 	// Most of the FormBase code is in page.FormBase. The code below specifically adds popup windows and controls
 	// to all standard forms, mostly for debug and development purposes.
 
-	f.FormBase.Init(ctx, self, path, id)
+	f.FormBase.Init(ctx, id)
 
 	if db.IsProfiling(ctx) {
 		btn := NewButton(f, "grProfileButton")

--- a/pkg/page/control/form_field_wrapper.go
+++ b/pkg/page/control/form_field_wrapper.go
@@ -43,12 +43,13 @@ type FormFieldWrapper struct {
 
 func NewFormField(parent page.ControlI, id string) *FormFieldWrapper {
 	p := &FormFieldWrapper{}
-	p.Init(p, parent, id)
+	p.Self = p
+	p.Init(parent, id)
 	return p
 }
 
-func (c *FormFieldWrapper) Init(self PanelI, parent page.ControlI, id string) {
-	c.ControlBase.Init(self, parent, id)
+func (c *FormFieldWrapper) Init(parent page.ControlI, id string) {
+	c.ControlBase.Init(parent, id)
 	c.Tag = "div"
 	c.Subtag = "div"
 	c.labelAttributes = html.NewAttributes().
@@ -376,5 +377,5 @@ func CalcWrapperID(wrapperId string, childCreator page.Creator, postfix string) 
 }
 
 func init() {
-	page.RegisterControl(FormFieldWrapper{})
+	page.RegisterControl(&FormFieldWrapper{})
 }

--- a/pkg/page/control/image.go
+++ b/pkg/page/control/image.go
@@ -28,13 +28,14 @@ type Image struct {
 // NewImage creates a new image.
 func NewImage(parent page.ControlI, id string) *Image {
 	i := &Image{}
-	i.Init(i, parent, id)
+	i.Self = i
+	i.Init(parent, id)
 	return i
 }
 
 // Init is called by subclasses. Normally you will not call this directly.
-func (i *Image) Init(self ImageI, parent page.ControlI, id string) {
-	i.ControlBase.Init(self, parent, id)
+func (i *Image) Init(parent page.ControlI, id string) {
+	i.ControlBase.Init(parent, id)
 	i.Tag = "img"
 	i.IsVoidTag = true
 	i.typ = "jpeg"
@@ -213,5 +214,5 @@ func GetImage(c page.ControlI, id string) *Image {
 }
 
 func init() {
-	page.RegisterControl(Image{})
+	page.RegisterControl(&Image{})
 }

--- a/pkg/page/control/image_capture.go
+++ b/pkg/page/control/image_capture.go
@@ -42,13 +42,14 @@ type ImageCapture struct {
 // NewImageCapture creates a new image capture panel.
 func NewImageCapture(parent page.ControlI, id string) *ImageCapture {
 	i := &ImageCapture{}
-	i.Init(i, parent, id)
+	i.Self = i
+	i.Init(parent, id)
 	return i
 }
 
 // Init is called by subclasses.
-func (i *ImageCapture) Init(self ImageCaptureI, parent page.ControlI, id string) {
-	i.ControlBase.Init(self, parent, id)
+func (i *ImageCapture) Init(parent page.ControlI, id string) {
+	i.ControlBase.Init(parent, id)
 	i.Tag = "div"
 	i.ParentForm().AddJavaScriptFile(config.GoraddAssets()+"/js/image-capture.js", false, nil)
 	i.typ = "jpeg"
@@ -269,5 +270,5 @@ func GetImageCapture(c page.ControlI, id string) *ImageCapture {
 }
 
 func init() {
-	page.RegisterControl(ImageCapture{})
+	page.RegisterControl(&ImageCapture{})
 }

--- a/pkg/page/control/list_checkbox.go
+++ b/pkg/page/control/list_checkbox.go
@@ -45,13 +45,14 @@ type CheckboxList struct {
 // NewCheckboxList creates a new CheckboxList
 func NewCheckboxList(parent page.ControlI, id string) *CheckboxList {
 	l := &CheckboxList{}
-	l.Init(l, parent, id)
+	l.Self = l
+	l.Init(parent, id)
 	return l
 }
 
 // Init is called by subclasses
-func (l *CheckboxList) Init(self CheckboxListI, parent page.ControlI, id string) {
-	l.MultiselectList.Init(self, parent, id)
+func (l *CheckboxList) Init(parent page.ControlI, id string) {
+	l.MultiselectList.Init(parent, id)
 	l.Tag = "div"
 	l.rowClass = "gr-cbl-row"
 	l.labelDrawingMode = page.DefaultCheckboxLabelDrawingMode
@@ -292,5 +293,5 @@ func GetCheckboxList(c page.ControlI, id string) *CheckboxList {
 }
 
 func init() {
-	page.RegisterControl(CheckboxList{})
+	page.RegisterControl(&CheckboxList{})
 }

--- a/pkg/page/control/list_multiselect.go
+++ b/pkg/page/control/list_multiselect.go
@@ -29,12 +29,13 @@ type MultiselectList struct {
 
 func NewMultiselectList(parent page.ControlI, id string) *MultiselectList {
 	l := &MultiselectList{}
-	l.Init(l, parent, id)
+	l.Self = l
+	l.Init(parent, id)
 	return l
 }
 
-func (l *MultiselectList) Init(self MultiselectListI, parent page.ControlI, id string) {
-	l.ControlBase.Init(self, parent, id)
+func (l *MultiselectList) Init(parent page.ControlI, id string) {
+	l.ControlBase.Init(parent, id)
 	l.ItemList = NewItemList(l)
 	l.selectedIds = map[string]bool{}
 	l.Tag = "select"
@@ -364,5 +365,5 @@ func GetMultiselectList(c page.ControlI, id string) *MultiselectList {
 }
 
 func init() {
-	page.RegisterControl(MultiselectList{})
+	page.RegisterControl(&MultiselectList{})
 }

--- a/pkg/page/control/list_ordered.go
+++ b/pkg/page/control/list_ordered.go
@@ -33,12 +33,13 @@ const (
 // NewOrderedList creates a new ordered list (ol tag).
 func NewOrderedList(parent page.ControlI, id string) *OrderedList {
 	t := &OrderedList{}
-	t.Init(t, parent, id)
+	t.Self = t
+	t.Init(parent, id)
 	return t
 }
 
-func (l *OrderedList) Init(self page.ControlI, parent page.ControlI, id string) {
-	l.UnorderedList.Init(self, parent, id)
+func (l *OrderedList) Init(parent page.ControlI, id string) {
+	l.UnorderedList.Init(parent, id)
 	l.Tag = "ol"
 }
 
@@ -156,5 +157,5 @@ func GetOrderedList(c page.ControlI, id string) *OrderedList {
 }
 
 func init() {
-	page.RegisterControl(OrderedList{})
+	page.RegisterControl(&OrderedList{})
 }

--- a/pkg/page/control/list_radio.go
+++ b/pkg/page/control/list_radio.go
@@ -46,13 +46,14 @@ type RadioList struct {
 // NewRadioList creates a new RadioList control.
 func NewRadioList(parent page.ControlI, id string) *RadioList {
 	l := &RadioList{}
-	l.Init(l, parent, id)
+	l.Self = l
+	l.Init(parent, id)
 	return l
 }
 
 // Init is called by subclasses.
-func (l *RadioList) Init(self RadioListI, parent page.ControlI, id string) {
-	l.SelectList.Init(self, parent, id)
+func (l *RadioList) Init(parent page.ControlI, id string) {
+	l.SelectList.Init(parent, id)
 	l.Tag = "div"
 	l.rowClass = "gr-cbl-row"
 	l.labelDrawingMode = page.DefaultCheckboxLabelDrawingMode
@@ -316,5 +317,5 @@ func GetRadioList(c page.ControlI, id string) *RadioList {
 }
 
 func init() {
-	page.RegisterControl(RadioList{})
+	page.RegisterControl(&RadioList{})
 }

--- a/pkg/page/control/list_select.go
+++ b/pkg/page/control/list_select.go
@@ -40,7 +40,7 @@ func NewSelectList(parent page.ControlI, id string) *SelectList {
 // Init is called by subclasses.
 func (l *SelectList) Init(parent page.ControlI, id string) {
 	l.ControlBase.Init(parent, id)
-	l.ItemList = NewItemList(l)
+	l.ItemList = NewItemList(l.this())
 	l.Tag = "select"
 }
 

--- a/pkg/page/control/list_select.go
+++ b/pkg/page/control/list_select.go
@@ -32,13 +32,14 @@ type SelectList struct {
 // NewSelectList creates a new select list
 func NewSelectList(parent page.ControlI, id string) *SelectList {
 	t := &SelectList{}
-	t.Init(t, parent, id)
+	t.Self = t
+	t.Init(parent, id)
 	return t
 }
 
 // Init is called by subclasses.
-func (l *SelectList) Init(self page.ControlI, parent page.ControlI, id string) {
-	l.ControlBase.Init(self, parent, id)
+func (l *SelectList) Init(parent page.ControlI, id string) {
+	l.ControlBase.Init(parent, id)
 	l.ItemList = NewItemList(l)
 	l.Tag = "select"
 }
@@ -320,5 +321,5 @@ func GetSelectList(c page.ControlI, id string) *SelectList {
 }
 
 func init() {
-	page.RegisterControl(SelectList{})
+	page.RegisterControl(&SelectList{})
 }

--- a/pkg/page/control/list_unordered.go
+++ b/pkg/page/control/list_unordered.go
@@ -41,12 +41,13 @@ const (
 // NewUnorderedList creates a new ul type list.
 func NewUnorderedList(parent page.ControlI, id string) *UnorderedList {
 	l := &UnorderedList{}
-	l.Init(l, parent, id)
+	l.Self = l
+	l.Init(parent, id)
 	return l
 }
 
-func (l *UnorderedList) Init(self page.ControlI, parent page.ControlI, id string) {
-	l.ControlBase.Init(self, parent, id)
+func (l *UnorderedList) Init(parent page.ControlI, id string) {
+	l.ControlBase.Init(parent, id)
 	l.ItemList = NewItemList(l)
 	l.Tag = "ul"
 	l.itemTag = "li"
@@ -200,5 +201,5 @@ func GetUnorderedList(c page.ControlI, id string) *UnorderedList {
 }
 
 func init() {
-	page.RegisterControl(UnorderedList{})
+	page.RegisterControl(&UnorderedList{})
 }

--- a/pkg/page/control/panel.go
+++ b/pkg/page/control/panel.go
@@ -25,12 +25,13 @@ type Panel struct {
 
 func NewPanel(parent page.ControlI, id string) *Panel {
 	p := &Panel{}
-	p.Init(p, parent, id)
+	p.Self = p
+	p.Init(parent, id)
 	return p
 }
 
-func (c *Panel) Init(self PanelI, parent page.ControlI, id string) {
-	c.ControlBase.Init(self, parent, id)
+func (c *Panel) Init(parent page.ControlI, id string) {
+	c.ControlBase.Init(parent, id)
 	c.Tag = "div"
 }
 
@@ -89,5 +90,5 @@ func GetPanel(c page.ControlI, id string) *Panel {
 }
 
 func init() {
-	page.RegisterControl(Panel{})
+	page.RegisterControl(&Panel{})
 }

--- a/pkg/page/control/proxy.go
+++ b/pkg/page/control/proxy.go
@@ -54,13 +54,14 @@ type Proxy struct {
 
 // NewProxy creates a new proxy. The parent must be the wrapping control of the objects that the proxy will manage.
 func NewProxy(parent page.ControlI, id string) *Proxy {
-	p := Proxy{}
+	p := &Proxy{}
+	p.Self = p
 	p.Init(parent, id)
-	return &p
+	return p
 }
 
 func (p *Proxy) Init(parent page.ControlI, id string) {
-	p.ControlBase.Init(p, parent, id)
+	p.ControlBase.Init(parent, id)
 	p.SetShouldAutoRender(true)
 	p.SetActionValue(javascript.JsCode(`goradd.proxyVal(event)`))
 }
@@ -217,5 +218,5 @@ func GetProxy(c page.ControlI, id string) *Proxy {
 }
 
 func init() {
-	page.RegisterControl(Proxy{})
+	page.RegisterControl(&Proxy{})
 }

--- a/pkg/page/control/radioButton.go
+++ b/pkg/page/control/radioButton.go
@@ -20,7 +20,8 @@ type RadioButton struct {
 // NewRadioButton creates a new radio button
 func NewRadioButton(parent page.ControlI, id string) *RadioButton {
 	c := &RadioButton{}
-	c.Init(c, parent, id)
+	c.Self = c
+	c.Init(parent, id)
 	return c
 }
 
@@ -147,5 +148,5 @@ func GetRadioButton(c page.ControlI, id string) *RadioButton {
 }
 
 func init() {
-	page.RegisterControl(RadioButton{})
+	page.RegisterControl(&RadioButton{})
 }

--- a/pkg/page/control/repeater.go
+++ b/pkg/page/control/repeater.go
@@ -29,14 +29,15 @@ type RepeaterHtmler interface {
 // NewTable creates a new table
 func NewRepeater(parent page.ControlI, id string) *Repeater {
 	r := &Repeater{}
-	r.Init(r, parent, id)
+	r.Self = r
+	r.Init(parent, id)
 	return r
 }
 
 // Init is an internal function that enables the object-oriented pattern of calling virtual functions used by the
 // goradd controls.
-func (r *Repeater) Init(self page.ControlI, parent page.ControlI, id string) {
-	r.ControlBase.Init(self, parent, id)
+func (r *Repeater) Init(parent page.ControlI, id string) {
+	r.ControlBase.Init(parent, id)
 	r.Tag = "div"
 }
 
@@ -214,5 +215,5 @@ func GetRepeater(c page.ControlI, id string) *Repeater {
 }
 
 func init() {
-	page.RegisterControl(Repeater{})
+	page.RegisterControl(&Repeater{})
 }

--- a/pkg/page/control/span.go
+++ b/pkg/page/control/span.go
@@ -18,12 +18,13 @@ type Span struct {
 
 func NewSpan(parent page.ControlI, id string) *Span {
 	p := &Span{}
-	p.Init(p, parent, id)
+	p.Self = p
+	p.Init(parent, id)
 	return p
 }
 
-func (c *Span) Init(self SpanI, parent page.ControlI, id string) {
-	c.Panel.Init(self, parent, id)
+func (c *Span) Init(parent page.ControlI, id string) {
+	c.Panel.Init(parent, id)
 	c.Tag = "span"
 }
 
@@ -58,5 +59,5 @@ func GetSpan(c page.ControlI, id string) *Span {
 }
 
 func init() {
-	page.RegisterControl(Span{})
+	page.RegisterControl(&Span{})
 }

--- a/pkg/page/control/table.go
+++ b/pkg/page/control/table.go
@@ -126,15 +126,16 @@ type Table struct {
 // NewTable creates a new table
 func NewTable(parent page.ControlI, id string) *Table {
 	t := &Table{}
-	t.Init(t, parent, id)
+	t.Self = t
+	t.Init(parent, id)
 	return t
 }
 
 // Init is an internal function that enables the object-oriented pattern of calling virtual functions used by the
 // goradd controls. You would only call this if you were implementing a "subclass" of the Table. Call it immediately after
 // creating your Table structure, passing the newly created table as "self".
-func (t *Table) Init(self page.ControlI, parent page.ControlI, id string) {
-	t.ControlBase.Init(self, parent, id)
+func (t *Table) Init(parent page.ControlI, id string) {
+	t.ControlBase.Init(parent, id)
 	t.Tag = "table"
 	t.columns = []ColumnI{}
 	t.sortHistoryLimit = 1
@@ -917,7 +918,7 @@ func GetTable(c page.ControlI, id string) *Table {
 }
 
 func init() {
-	page.RegisterControl(Table{})
+	page.RegisterControl(&Table{})
 }
 
 // Similar to the control registry, since columns rely on the "this" variable to deserialize, we

--- a/pkg/page/control/table_paged.go
+++ b/pkg/page/control/table_paged.go
@@ -18,12 +18,13 @@ type PagedTable struct {
 
 func NewPagedTable(parent page.ControlI, id string) *PagedTable {
 	t := &PagedTable{}
-	t.Init(t, parent, id)
+	t.Self = t
+	t.Init(parent, id)
 	return t
 }
 
-func (t *PagedTable) Init(self page.ControlI, parent page.ControlI, id string) {
-	t.Table.Init(self, parent, id)
+func (t *PagedTable) Init(parent page.ControlI, id string) {
+	t.Table.Init(parent, id)
 	t.PagedControl.SetPageSize(0) // use the application default
 }
 
@@ -140,5 +141,5 @@ func GetPagedTable(c page.ControlI, id string) *PagedTable {
 }
 
 func init() {
-	page.RegisterControl(PagedTable{})
+	page.RegisterControl(&PagedTable{})
 }

--- a/pkg/page/control/table_paged_test.go
+++ b/pkg/page/control/table_paged_test.go
@@ -35,7 +35,8 @@ func TestPagedTable_Serialize(t *testing.T) {
 	enc := gob.NewEncoder(&buf)
 
 	f := &pagedTableTestForm{}
-	f.FormBase.Init(nil, f, "", "MockFormId")
+	f.Self = f
+	f.FormBase.Init(context.Background(), "MockFormId")
 
 	f.AddControls(context.Background(),
 		PagedTableCreator{

--- a/pkg/page/control/table_select.go
+++ b/pkg/page/control/table_select.go
@@ -29,12 +29,13 @@ type SelectTable struct {
 
 func NewSelectTable(parent page.ControlI, id string) *SelectTable {
 	t := &SelectTable{}
-	t.Init(t, parent, id)
+	t.Self = t
+	t.Init(parent, id)
 	return t
 }
 
-func (t *SelectTable) Init(self page.ControlI, parent page.ControlI, id string) {
-	t.Table.Init(self, parent, id)
+func (t *SelectTable) Init(parent page.ControlI, id string) {
+	t.Table.Init(parent, id)
 	t.ParentForm().AddJavaScriptFile(config.GoraddAssets() + "/js/goradd-scrollIntoView.js", false, nil)
 	t.ParentForm().AddJavaScriptFile(config.GoraddAssets() + "/js/table-select.js", false, nil)
 	t.SetAttribute("tabindex", 0); // Make the entire table focusable and selectable. This can be overridden later if needed.
@@ -236,5 +237,5 @@ func GetSelectTable(c page.ControlI, id string) *SelectTable {
 }
 
 func init() {
-	page.RegisterControl(SelectTable{})
+	page.RegisterControl(&SelectTable{})
 }

--- a/pkg/page/control/textbox.go
+++ b/pkg/page/control/textbox.go
@@ -68,13 +68,14 @@ type Textbox struct {
 // NewTextbox creates a new goradd textbox html widget.
 func NewTextbox(parent page.ControlI, id string) *Textbox {
 	t := &Textbox{}
-	t.Init(t, parent, id)
+	t.Self = t
+	t.Init(parent, id)
 	return t
 }
 
 // Initializes a textbox. Normally you will not call this directly.
-func (t *Textbox) Init(self TextboxI, parent page.ControlI, id string) {
-	t.ControlBase.Init(self, parent, id)
+func (t *Textbox) Init(parent page.ControlI, id string) {
+	t.ControlBase.Init(parent, id)
 
 	t.Tag = "input"
 	t.IsVoidTag = true
@@ -500,5 +501,5 @@ func init() {
 	// gob.Register(&Textbox{}) register control.Textbox instead
 	gob.Register(MaxLengthValidator{})
 	gob.Register(MinLengthValidator{})
-	page.RegisterControl(Textbox{})
+	page.RegisterControl(&Textbox{})
 }

--- a/pkg/page/control/textbox_date.go
+++ b/pkg/page/control/textbox_date.go
@@ -28,12 +28,13 @@ type DateTextbox struct {
 // NewDateTextbox creates a new DateTextbox.
 func NewDateTextbox(parent page.ControlI, id string) *DateTextbox {
 	d := &DateTextbox{}
-	d.Init(d, parent, id)
+	d.Self = d
+	d.Init(parent, id)
 	return d
 }
 
-func (d *DateTextbox) Init(self TextboxI, parent page.ControlI, id string) {
-	d.Textbox.Init(self, parent, id)
+func (d *DateTextbox) Init(parent page.ControlI, id string) {
+	d.Textbox.Init(parent, id)
 	d.ValidateWith(DateValidator{})
 	d.format = datetime.UsDateTime
 }
@@ -236,5 +237,5 @@ func GetDateTextbox(c page.ControlI, id string) *DateTextbox {
 
 func init() {
 	gob.Register(DateValidator{})
-	page.RegisterControl(DateTextbox{})
+	page.RegisterControl(&DateTextbox{})
 }

--- a/pkg/page/control/textbox_email.go
+++ b/pkg/page/control/textbox_email.go
@@ -26,14 +26,15 @@ type EmailTextbox struct {
 // multi will allow the textbox to accept multiple email addresses separated by a comma.
 func NewEmailTextbox(parent page.ControlI, id string) *EmailTextbox {
 	t := &EmailTextbox{}
-	t.Init(t, parent, id)
-	t.maxItemCount = 1
-	t.SetType(TextboxTypeEmail)
+	t.Self = t
+	t.Init(parent, id)
 	return t
 }
 
-func (t *EmailTextbox) Init(self TextboxI, parent page.ControlI, id string) {
-	t.Textbox.Init(self, parent, id)
+func (t *EmailTextbox) Init(parent page.ControlI, id string) {
+	t.Textbox.Init(parent, id)
+	t.maxItemCount = 1
+	t.SetType(TextboxTypeEmail)
 }
 
 func (t *EmailTextbox) this() EmailTextboxI {
@@ -194,5 +195,5 @@ func GetEmailTextbox(c page.ControlI, id string) *EmailTextbox {
 }
 
 func init() {
-	page.RegisterControl(EmailTextbox{})
+	page.RegisterControl(&EmailTextbox{})
 }

--- a/pkg/page/control/textbox_float.go
+++ b/pkg/page/control/textbox_float.go
@@ -21,12 +21,13 @@ type FloatTextbox struct {
 
 func NewFloatTextbox(parent page.ControlI, id string) *FloatTextbox {
 	t := &FloatTextbox{}
-	t.Init(t, parent, id)
+	t.Self = t
+	t.Init(parent, id)
 	return t
 }
 
-func (t *FloatTextbox) Init(self TextboxI, parent page.ControlI, id string) {
-	t.Textbox.Init(self, parent, id)
+func (t *FloatTextbox) Init(parent page.ControlI, id string) {
+	t.Textbox.Init(parent, id)
 	t.ValidateWith(FloatValidator{})
 }
 
@@ -222,5 +223,5 @@ func init() {
 	gob.Register(MaxFloatValidator{})
 	gob.Register(MinFloatValidator{})
 	gob.Register(FloatValidator{})
-	page.RegisterControl(FloatTextbox{})
+	page.RegisterControl(&FloatTextbox{})
 }

--- a/pkg/page/control/textbox_integer.go
+++ b/pkg/page/control/textbox_integer.go
@@ -22,12 +22,13 @@ type IntegerTextbox struct {
 
 func NewIntegerTextbox(parent page.ControlI, id string) *IntegerTextbox {
 	t := &IntegerTextbox{}
-	t.Init(t, parent, id)
+	t.Self = t
+	t.Init(parent, id)
 	return t
 }
 
-func (t *IntegerTextbox) Init(self TextboxI, parent page.ControlI, id string) {
-	t.Textbox.Init(self, parent, id)
+func (t *IntegerTextbox) Init(parent page.ControlI, id string) {
+	t.Textbox.Init(parent, id)
 	t.ValidateWith(IntValidator{})
 }
 
@@ -241,5 +242,5 @@ func init() {
 	gob.Register(MaxIntValidator{})
 	gob.Register(MinIntValidator{})
 	gob.Register(IntValidator{})
-	page.RegisterControl(IntegerTextbox{})
+	page.RegisterControl(&IntegerTextbox{})
 }

--- a/pkg/page/control_registry.go
+++ b/pkg/page/control_registry.go
@@ -1,0 +1,70 @@
+package page
+
+import (
+	"hash/fnv"
+	"reflect"
+)
+
+var controlRegistry = make(map[uint64]reflect.Type)
+var controlRegistryIds = make(map[reflect.Type]uint64)
+
+// RegisterControl registers the control for the serialize/deserialize process. You should call this
+// for each control from an init() function.
+//
+// As a control is added to the registry, it is assigned an id. That id is used to identify a control
+// in the serialization and deserialization process.  We make a significant attempt to prevent the
+// addition of controls to an application from causing a change in these ids, since an id change will
+// also cause the current page cache to be invalidated. We use a hashing function, and a collision detector
+// to do that. If a collision is detected, it will panic, and you should change the hash salt and try again,
+// as well as bump the cache version to invalidate the cache.
+func RegisterControl(i ControlI) {
+	typ := reflect.Indirect(reflect.ValueOf(i)).Type()
+	if _, ok := controlRegistryIds[typ]; ok {
+		panic("Registering duplicate control")
+	}
+	hash := fnv.New64()
+	n := typ.Name()
+	if n == "" {
+		panic("type problem")
+	}
+	_,_ = hash.Write([]byte(ControlRegistrySalt))
+	_,_ = hash.Write([]byte(typ.PkgPath()))
+	_,_ = hash.Write([]byte(typ.Name()))
+	id := hash.Sum64()
+	if t,ok := controlRegistry[id]; ok {
+		panic("The control registry has detected a collision. " +
+			t.Name() + " has collided with " + typ.Name() + ". " +
+		"This is a very rare situation, but needs " +
+			"to be fixed. To fix it, change the ControlRegistrySalt value, and also change the " +
+			"PageCacheVersionID")
+	}
+	controlRegistry[id] = typ
+	controlRegistryIds[typ] = id
+}
+
+func controlRegistryID(i ControlI) uint64 {
+	val := reflect.Indirect(reflect.ValueOf(i))
+	typ := val.Type()
+	id, ok := controlRegistryIds[typ]
+	if !ok {
+		panic("ControlBase type is not registered: " + typ.String())
+	}
+	return id
+}
+
+func createRegisteredControl(registryID uint64, p *Page) ControlI {
+	typ := controlRegistry[registryID]
+	v := reflect.New(typ)
+	c := v.Interface().(ControlI)
+	c.control().Self = c
+	c.control().page = p
+	return c
+}
+
+func controlIsRegistered(i interface{}) bool {
+	typ := reflect.Indirect(reflect.ValueOf(i)).Type()
+	_,ok := controlRegistryIds[typ]
+	return ok
+}
+
+

--- a/pkg/page/form_base.go
+++ b/pkg/page/form_base.go
@@ -22,7 +22,8 @@ import (
 type FormI interface {
 	ControlI
 	// Init initializes the base structures of the form. Do this before adding controls to the form.
-	Init(ctx context.Context, self FormI, path string, id string)
+	// Note that this signature is different than that of the Init function in FormBase.
+	Init(ctx context.Context, id string)
 	PageDrawingFunction() PageDrawFunc
 
 	LoadControls(ctx context.Context)
@@ -63,7 +64,7 @@ type FormBase struct {
 }
 
 // Init initializes the form control. Note that ctx might be nil if we are unit testing.
-func (f *FormBase) Init(ctx context.Context, self FormI, path string, id string) {
+func (f *FormBase) Init(ctx context.Context, id string) {
 	var p = &Page{}
 	p.Init()
 
@@ -72,7 +73,9 @@ func (f *FormBase) Init(ctx context.Context, self FormI, path string, id string)
 		panic("Forms must have an id assigned")
 	}
 	f.ControlBase.id = id
-	f.ControlBase.Init(self, nil, id)
+
+	// TODO: remove first param from Init call below
+	f.ControlBase.Init(nil, id)
 	f.Tag = "form"
 }
 

--- a/pkg/page/page.go
+++ b/pkg/page/page.go
@@ -16,7 +16,6 @@ import (
 	reflect2 "github.com/goradd/goradd/pkg/reflect"
 	"github.com/goradd/goradd/pkg/session"
 	strings2 "github.com/goradd/goradd/pkg/strings"
-	"hash/fnv"
 	"reflect"
 	"strconv"
 	"strings"
@@ -597,55 +596,5 @@ func (p *Page) Cleanup() {
 	p.Form().RangeSelfAndAllChildren(func(ctrl ControlI) {
 		ctrl.Cleanup()
 	})
-}
-
-var controlRegistry = make(map[uint64]reflect.Type)
-var controlRegistryIds = make(map[reflect.Type]uint64)
-
-// RegisterControl registers the control for the serialize/deserialize process. You should call this
-// for each control from an init() function.
-//
-// As a control is added to the registry, it is assigned an id. That id is used to identify a control
-// in the serialization and deserialization process.  We make a significant attempt to prevent the
-// addition of controls to an application from causing a change in these ids, since an id change will
-// also cause the current page cache to be invalidated. We use a hashing function, and a collision detector
-// to do that. If a collision is detected, it will panic, and you should change the hash salt and try again,
-// as well as bump the cache version to invalidate the cache.
-func RegisterControl(i interface{}) {
-	typ := reflect.TypeOf(i)
-	if _, ok := controlRegistryIds[typ]; ok {
-		panic("Registering duplicate control")
-	}
-	hash := fnv.New64()
-	_,_ = hash.Write([]byte(ControlRegistrySalt))
-	_,_ = hash.Write([]byte(typ.PkgPath()))
-	_,_ = hash.Write([]byte(typ.Name()))
-	id := hash.Sum64()
-	if _,ok := controlRegistry[id]; ok {
-		panic("The control registry has detected a collision. This is a very rare situation, but needs " +
-			"to be fixed. To fix it, change the ControlRegistrySalt value, and also change the " +
-			"PageCacheVersionID")
-	}
-	controlRegistry[id] = typ
-	controlRegistryIds[typ] = id
-}
-
-func controlRegistryID(i ControlI) uint64 {
-	val := reflect.Indirect(reflect.ValueOf(i))
-	typ := val.Type()
-	id, ok := controlRegistryIds[typ]
-	if !ok {
-		panic("ControlBase type is not registered: " + typ.String())
-	}
-	return id
-}
-
-func createRegisteredControl(registryID uint64, p *Page) ControlI {
-	typ := controlRegistry[registryID]
-	v := reflect.New(typ)
-	c := v.Interface().(ControlI)
-	c.control().Base.Self = c
-	c.control().page = p
-	return c
 }
 

--- a/pkg/page/page_cache.go
+++ b/pkg/page/page_cache.go
@@ -27,6 +27,10 @@ func GetPageCache() PageCacheI {
 	return pageCache
 }
 
+func HasPage(pageStateId string) bool {
+	return pageCache.Has(pageStateId)
+}
+
 // FastPageCache is an in memory page cache that does no serialization and uses an LRU cache of page objects.
 // Objects that are too old are removed, and if the cache is full,
 // the oldest item(s) will be removed. When a page is updated, it is moved to the top. Whenever an item is set,

--- a/pkg/page/page_encoder_test.go
+++ b/pkg/page/page_encoder_test.go
@@ -40,7 +40,8 @@ type BasicForm struct {
 
 func CreateBasicForm(ctx context.Context) page.FormI {
 	f := &BasicForm{}
-	f.Init(ctx, f, "/test/BasicForm", "BasicForm")
+	f.Self = f
+	f.FormBase.Init(ctx, "BasicForm")
 	f.createControls(ctx)
 	return f
 }
@@ -81,7 +82,7 @@ func TestBasicFormEncoding(t *testing.T) {
 	var form = CreateBasicForm(nil)
 	var b bytes.Buffer
 
-	page.RegisterControl(BasicForm{})
+	page.RegisterControl(&BasicForm{})
 
 	pe := page.GobPageEncoder{}
 	e := pe.NewEncoder(&b)

--- a/pkg/page/widget/item_list_panel.go
+++ b/pkg/page/widget/item_list_panel.go
@@ -32,14 +32,14 @@ type ItemListPanel struct {
 
 func NewItemListPanel(parent page.ControlI, id string) *ItemListPanel {
 	p := &ItemListPanel{}
-	p.Init(p, parent, id)
-	p.ParentForm().AddStyleSheetFile(config.GoraddAssets()+"/css/item-list-panel.css", nil)
-
+	p.Self = p
+	p.Init(parent, id)
 	return p
 }
 
-func (p *ItemListPanel) Init(self ItemListPanelI, parent page.ControlI, id string) {
-	p.Panel.Init(self, parent, id)
+func (p *ItemListPanel) Init(parent page.ControlI, id string) {
+	p.Panel.Init(parent, id)
+	p.ParentForm().AddStyleSheetFile(config.GoraddAssets()+"/css/item-list-panel.css", nil)
 	p.FilterPanel = NewPanel(p, p.ID()+"-filter")
 	p.ScrollPanel = NewPanel(p, p.ID()+"-scroller")
 	p.ButtonPanel = NewPanel(p, p.ID()+"-btnpnl")

--- a/test/browsertest/jsunit_form.go
+++ b/test/browsertest/jsunit_form.go
@@ -19,9 +19,8 @@ type JsUnitForm struct {
 	RunButton *Button
 }
 
-func NewJsUnitForm(ctx context.Context) page.FormI {
-	f := &JsUnitForm{}
-	f.Init(ctx, f, JsUnitTestFormPath, JsUnitTestFormId)
+func (f *JsUnitForm)Init(ctx context.Context, formID string) {
+	f.FormBase.Init(ctx, formID)
 	f.AddRelatedFiles()
 
 	f.Results = NewPanel(f, "results")
@@ -29,7 +28,6 @@ func NewJsUnitForm(ctx context.Context) page.FormI {
 	f.RunButton = NewButton(f, "startButton")
 	f.RunButton.SetText("Start Test")
 	f.RunButton.OnSubmit(action.Javascript("goradd.jsUnit.run(goradd.testsuite, 'results')"))
-	return f
 }
 
 func (f *JsUnitForm) AddRelatedFiles() {
@@ -54,6 +52,5 @@ func testJsUnit(t *TestForm)  {
 }
 
 func init() {
-	page.RegisterPage(JsUnitTestFormPath, NewJsUnitForm, JsUnitTestFormId)
-	page.RegisterControl(JsUnitForm{})
+	page.RegisterForm(JsUnitTestFormPath, &JsUnitForm{}, JsUnitTestFormId)
 }

--- a/test/browsertest/test_controller.go
+++ b/test/browsertest/test_controller.go
@@ -48,14 +48,15 @@ type TestController struct {
 
 func NewTestController(parent page.ControlI, id string) *TestController {
 	p := new(TestController)
-	p.Init(p, parent, id)
-	p.Tag = "pre"
-	p.stepChannel = make(chan stepItemType, 1)
+	p.Self = p
+	p.Init(parent, id)
 	return p
 }
 
-func (p *TestController) Init(self control.PanelI, parent page.ControlI, id string) {
-	p.Panel.Init(p, parent, id)
+func (p *TestController) Init(parent page.ControlI, id string) {
+	p.Panel.Init(parent, id)
+	p.Tag = "pre"
+	p.stepChannel = make(chan stepItemType, 1)
 	p.ParentForm().AddJavaScriptFile(filepath.Join(TestAssets(), "js", "test_controller.js"), false, nil)
 	// Use declarative attribute to attach javascript to the control
 	p.SetDataAttribute("grWidget", "goradd.testController")

--- a/test/browsertest/test_form.go
+++ b/test/browsertest/test_form.go
@@ -43,21 +43,19 @@ type TestForm struct {
 	usingForm		bool
 }
 
-func NewTestForm(ctx context.Context) page.FormI {
-	f := &TestForm{}
-	f.Init(ctx, f, TestFormPath, TestFormId)
+func (form *TestForm) Init(ctx context.Context, formID string) {
+	form.FormBase.Init(ctx, formID)
 	//f.Page().SetDrawFunction(LoginPageTmpl)
-	f.AddRelatedFiles()
-	f.createControls(ctx)
-	f.WatchChannel(ctx, "redraw")
-	testFormPageState = f.Page().StateID()
+	form.AddRelatedFiles()
+	form.createControls(ctx)
+	form.WatchChannel(ctx, "redraw")
+	testFormPageState = form.Page().StateID()
 
 	grctx := page.GetContext(ctx)
 
 	if _, ok := grctx.FormValue("all"); ok {
-		f.On(event2.MessengerReady(), action.Ajax(f.ID(), TestAllAction))
+		form.On(event2.MessengerReady(), action.Ajax(form.ID(), TestAllAction))
 	}
-	return f
 }
 
 func (form *TestForm) createControls(ctx context.Context) {
@@ -152,7 +150,7 @@ func (form *TestForm) F(f func(page.FormI) ) {
 	testForm := pc.Get(form.Controller.pagestate).Form()
 	{
 		form.usingForm = true
-		defer func(){form.usingForm = false}()
+		defer func(){ form.usingForm = false}()
 		f(testForm)
 	}
 	pc.Set(form.Controller.pagestate, testForm.Page())
@@ -465,5 +463,5 @@ func (form *TestForm) NoSerialize() bool {
 }
 
 func init() {
-	page.RegisterPage(TestFormPath, NewTestForm, TestFormId)
+	page.RegisterForm(TestFormPath, &TestForm{}, TestFormId)
 }

--- a/test/browsertest/test_form.tpl.go
+++ b/test/browsertest/test_form.tpl.go
@@ -7,17 +7,17 @@ import (
 	"context"
 )
 
-func (ctrl *TestForm) AddHeadTags() {
-	ctrl.FormBase.AddHeadTags()
+func (form *TestForm) AddHeadTags() {
+	form.FormBase.AddHeadTags()
 	if "Tests" != "" {
-		ctrl.Page().SetTitle("Tests")
+		form.Page().SetTitle("Tests")
 	}
 
 	// double up to deal with body attributes if they exist
-	ctrl.Page().BodyAttributes = ``
+	form.Page().BodyAttributes = ``
 }
 
-func (ctrl *TestForm) DrawTemplate(ctx context.Context, buf *bytes.Buffer) (err error) {
+func (form *TestForm) DrawTemplate(ctx context.Context, buf *bytes.Buffer) (err error) {
 
 	buf.WriteString(`
 <h1>Browser Based Tests</h1>
@@ -27,7 +27,7 @@ func (ctrl *TestForm) DrawTemplate(ctx context.Context, buf *bytes.Buffer) (err 
 `)
 
 	{
-		err := ctrl.Page().GetControl("test-list").Draw(ctx, buf)
+		err := form.Page().GetControl("test-list").Draw(ctx, buf)
 		if err != nil {
 			return err
 		}
@@ -40,7 +40,7 @@ func (ctrl *TestForm) DrawTemplate(ctx context.Context, buf *bytes.Buffer) (err 
 `)
 
 	{
-		err := ctrl.Page().GetControl("run-button").Draw(ctx, buf)
+		err := form.Page().GetControl("run-button").Draw(ctx, buf)
 		if err != nil {
 			return err
 		}
@@ -53,7 +53,7 @@ func (ctrl *TestForm) DrawTemplate(ctx context.Context, buf *bytes.Buffer) (err 
 `)
 
 	{
-		err := ctrl.Page().GetControl("run-all-button").Draw(ctx, buf)
+		err := form.Page().GetControl("run-all-button").Draw(ctx, buf)
 		if err != nil {
 			return err
 		}
@@ -68,7 +68,7 @@ Currently running:
 `)
 
 	{
-		err := ctrl.Page().GetControl("running-label").Draw(ctx, buf)
+		err := form.Page().GetControl("running-label").Draw(ctx, buf)
 		if err != nil {
 			return err
 		}
@@ -81,7 +81,7 @@ Currently running:
 `)
 
 	{
-		err := ctrl.Page().GetControl("controller").Draw(ctx, buf)
+		err := form.Page().GetControl("controller").Draw(ctx, buf)
 		if err != nil {
 			return err
 		}

--- a/web/examples/controls/controls_form.go
+++ b/web/examples/controls/controls_form.go
@@ -30,9 +30,8 @@ type controlEntry struct {
 
 var controls []controlEntry
 
-func NewControlsForm(ctx context.Context) page.FormI {
-	f := &ControlsForm{}
-	f.Init(ctx, f, ControlsFormPath, ControlsFormId)
+func (f *ControlsForm) Init(ctx context.Context, formID string) {
+	f.FormBase.Init(ctx, formID)
 	f.AddRelatedFiles()
 
 	f.AddControls(ctx,
@@ -43,9 +42,7 @@ func NewControlsForm(ctx context.Context) page.FormI {
 		PanelCreator{
 			ID:             ControlsFormDetailID,
 		},
-		)
-
-	return f
+	)
 }
 
 func (f *ControlsForm) LoadControls(ctx context.Context) {
@@ -96,6 +93,5 @@ func RegisterPanel(key string,
 }
 
 func init() {
-	page.RegisterControl(ControlsForm{})
-	page.RegisterPage(ControlsFormPath, NewControlsForm, ControlsFormId)
+	page.RegisterForm(ControlsFormPath, &ControlsForm{}, ControlsFormId)
 }

--- a/web/examples/controls/controls_form.tpl.go
+++ b/web/examples/controls/controls_form.tpl.go
@@ -9,8 +9,8 @@ import (
 
 func (ctrl *ControlsForm) AddHeadTags() {
 	ctrl.FormBase.AddHeadTags()
-	if "ControlBase Examples" != "" {
-		ctrl.Page().SetTitle("ControlBase Examples")
+	if "Control Examples" != "" {
+		ctrl.Page().SetTitle("Control Examples")
 	}
 
 	// double up to deal with body attributes if they exist
@@ -21,7 +21,7 @@ func (ctrl *ControlsForm) AddHeadTags() {
 func (ctrl *ControlsForm) DrawTemplate(ctx context.Context, buf *bytes.Buffer) (err error) {
 
 	buf.WriteString(`
-<h1>ControlBase Examples</h1>
+<h1>Control Examples</h1>
 <div class="controlList_scroll">
 	`)
 

--- a/web/examples/controls/panels/checkboxes.go
+++ b/web/examples/controls/panels/checkboxes.go
@@ -32,7 +32,12 @@ func (p *CheckboxPanel) Action(ctx context.Context, a page.ActionParams) {
 
 func NewCheckboxPanel(ctx context.Context, parent page.ControlI) {
 	p := &CheckboxPanel{}
-	p.Panel.Init(p, parent, "checkboxPanel")
+	p.Self = p
+	p.Init(ctx, parent, "checkboxPanel")
+}
+
+func (p *CheckboxPanel) Init(ctx context.Context, parent page.ControlI, id string) {
+	p.Panel.Init(parent, "checkboxPanel")
 	p.AddControls(ctx,
 		FormFieldWrapperCreator{
 			ID:"checkbox1-ff",
@@ -91,7 +96,7 @@ func NewCheckboxPanel(ctx context.Context, parent page.ControlI) {
 func init() {
 	browsertest.RegisterTestFunction("Checkbox Ajax Submit", testCheckboxAjaxSubmit)
 	browsertest.RegisterTestFunction("Checkbox Server Submit", testCheckboxServerSubmit)
-	page.RegisterControl(CheckboxPanel{})
+	page.RegisterControl(&CheckboxPanel{})
 }
 
 // testPlain exercises the plain text box

--- a/web/examples/controls/panels/default.go
+++ b/web/examples/controls/panels/default.go
@@ -24,9 +24,10 @@ type DefaultPanel struct {
 
 func NewDefaultPanel(ctx context.Context, parent page.ControlI) {
 	p := &DefaultPanel{}
-	p.Panel.Init(p, parent, "defaultPanel")
+	p.Self = p
+	p.Panel.Init(parent, "defaultPanel")
 }
 
 func init() {
-	page.RegisterControl(DefaultPanel{})
+	page.RegisterControl(&DefaultPanel{})
 }

--- a/web/examples/controls/panels/default.tpl.go
+++ b/web/examples/controls/panels/default.tpl.go
@@ -10,7 +10,7 @@ import (
 func (ctrl *DefaultPanel) DrawTemplate(ctx context.Context, buf *bytes.Buffer) (err error) {
 
 	buf.WriteString(`
-<h1>ControlBase Examples</h1>
+<h1>Control Examples</h1>
 <p>
 These pages demonstrate the various supported controls that are available in goradd. These
 controls fall in to these categories:

--- a/web/examples/controls/panels/hlist.go
+++ b/web/examples/controls/panels/hlist.go
@@ -31,6 +31,13 @@ type HListPanel struct {
 }
 
 func NewHListPanel(ctx context.Context, parent page.ControlI) {
+	p := &HListPanel{}
+	p.Self = p
+	p.Init(ctx, parent, "HListPanel")
+}
+
+func (p *HListPanel) Init(ctx context.Context, parent page.ControlI, id string) {
+	p.Panel.Init(parent, id)
 	itemList := []ListValue{
 		{"First", 1},
 		{"Second", 2},
@@ -38,9 +45,6 @@ func NewHListPanel(ctx context.Context, parent page.ControlI) {
 		{"Fourth", 4},
 		{"Fifth", 5},
 	}
-
-	p := &HListPanel{}
-	p.Panel.Init(p, parent, "HListPanel")
 	p.AddControls(ctx,
 		OrderedListCreator{
 			ID: "orderedList",
@@ -102,5 +106,5 @@ func testHListSubmit(t *browsertest.TestForm, btnID string) {
 }
 
 func init() {
-	page.RegisterControl(HListPanel{})
+	page.RegisterControl(&HListPanel{})
 }

--- a/web/examples/controls/panels/repeater.go
+++ b/web/examples/controls/panels/repeater.go
@@ -15,13 +15,18 @@ type RepeaterPanel struct {
 
 func NewRepeaterPanel(ctx context.Context, parent page.ControlI) {
 	p := &RepeaterPanel{}
-	p.Panel.Init(p, parent, "repeaterPanel")
+	p.Self = p
+	p.Init(ctx, parent, "repeaterPanel")
+}
+
+func (p *RepeaterPanel) Init(ctx context.Context, parent page.ControlI, id string) {
+	p.Panel.Init(parent, "repeaterPanel")
 	p.AddControls(ctx,
 		RepeaterCreator{
-			ID: "repeater1",
-			ItemHtmler: p,
+			ID:           "repeater1",
+			ItemHtmler:   p,
 			DataProvider: p,
-			PageSize:5,
+			PageSize:     5,
 		},
 		// A DataPager can be a standalone control, which you draw manually
 		DataPagerCreator{
@@ -33,7 +38,7 @@ func NewRepeaterPanel(ctx context.Context, parent page.ControlI) {
 
 // BindData satisfies the data provider interface so that the parent panel of the table
 // is the one that is providing the table.
-func (f *RepeaterPanel) BindData(ctx context.Context, s DataManagerI) {
+func (p *RepeaterPanel) BindData(ctx context.Context, s DataManagerI) {
 	switch s.ID() {
 	case "repeater1":
 		t := s.(PagedControlI)
@@ -43,13 +48,13 @@ func (f *RepeaterPanel) BindData(ctx context.Context, s DataManagerI) {
 	}
 }
 
-func (f *RepeaterPanel) RepeaterHtml(ctx context.Context, r RepeaterI, i int, data interface{}, buf *bytes.Buffer) error {
+func (p *RepeaterPanel) RepeaterHtml(ctx context.Context, r RepeaterI, i int, data interface{}, buf *bytes.Buffer) error {
 	d := data.(TableMapData)
 	buf.WriteString(fmt.Sprintf(`<div>ID: %s, Name: %s</div>`, d["id"], d["name"]))
 	return nil
 }
 
 func init() {
-	page.RegisterControl(RepeaterPanel{})
+	page.RegisterControl(&RepeaterPanel{})
 }
 

--- a/web/examples/controls/panels/selectlist.go
+++ b/web/examples/controls/panels/selectlist.go
@@ -16,6 +16,14 @@ type SelectListPanel struct {
 }
 
 func NewSelectListPanel(ctx context.Context, parent page.ControlI) {
+	p := &SelectListPanel{}
+	p.Self = p
+	p.Init(ctx, parent, "selectListPanel")
+}
+
+func (p *SelectListPanel) Init(ctx context.Context, parent page.ControlI, id string) {
+	p.Panel.Init(parent, id)
+
 	itemList := []ListValue{
 		{"First", 1},
 		{"Second", 2},
@@ -27,8 +35,6 @@ func NewSelectListPanel(ctx context.Context, parent page.ControlI) {
 		{"Eighth", 8},
 	}
 
-	p := &SelectListPanel{}
-	p.Panel.Init(p, parent, "selectListPanel")
 	p.AddControls(ctx,
 		FormFieldWrapperCreator{
 			Label: "Standard SelectList",
@@ -113,6 +119,8 @@ func NewSelectListPanel(ctx context.Context, parent page.ControlI) {
 
 	)
 }
+
+
 
 func (p *SelectListPanel) Action(ctx context.Context, a page.ActionParams) {
 	switch a.ID {
@@ -205,6 +213,6 @@ func testSelectListSubmit(t *browsertest.TestForm, btnID string) {
 */
 
 func init() {
-	page.RegisterControl(SelectListPanel{})
+	page.RegisterControl(&SelectListPanel{})
 }
 

--- a/web/examples/controls/panels/table.go
+++ b/web/examples/controls/panels/table.go
@@ -70,12 +70,18 @@ var tableSliceData = []TableSliceData{
 
 func NewTablePanel(ctx context.Context, parent page.ControlI) {
 	p := &TablePanel{}
-	p.Panel.Init(p, parent, "tablePanel")
+	p.Self = p
+	p.Init(ctx, parent, "tablePanel")
+}
+
+func (p *TablePanel) Init(ctx context.Context, parent page.ControlI, id string) {
+	p.Panel.Init(parent,id)
+
 	p.AddControls(ctx,
 		PagedTableCreator{
-			ID: "table1",
+			ID:             "table1",
 			HeaderRowCount: 1,
-			DataProvider: p,
+			DataProvider:   p,
 			Columns:[]ColumnCreator {
 				column.TexterColumnCreator{
 					Texter: "tablePanel",
@@ -125,7 +131,7 @@ func NewTablePanel(ctx context.Context, parent page.ControlI) {
 
 // BindData satisfies the data provider interface so that the parent panel of the table
 // is the one that is providing the table.
-func (f *TablePanel) BindData(ctx context.Context, s DataManagerI) {
+func (p *TablePanel) BindData(ctx context.Context, s DataManagerI) {
 	switch s.ID() {
 	case "table1":
 		t := s.(PagedControlI)
@@ -142,7 +148,7 @@ func (f *TablePanel) BindData(ctx context.Context, s DataManagerI) {
 }
 
 // CellText here satisfies the CellTexter interface so that the panel can provide the text for a cell.
-func (f *TablePanel) CellText(ctx context.Context, col ColumnI, rowNum int, colNum int, data interface{}) string {
+func (p *TablePanel) CellText(ctx context.Context, col ColumnI, rowNum int, colNum int, data interface{}) string {
 	// Here is an example of how to figure out what table we are talking about.
 	tid := col.ParentTable().ID()
 	switch tid {
@@ -155,5 +161,5 @@ func (f *TablePanel) CellText(ctx context.Context, col ColumnI, rowNum int, colN
 }
 
 func init() {
-	page.RegisterControl(TablePanel{})
+	page.RegisterControl(&TablePanel{})
 }

--- a/web/examples/controls/panels/table_checkbox.go
+++ b/web/examples/controls/panels/table_checkbox.go
@@ -40,7 +40,12 @@ func (c SelectedProvider) IsChecked(data interface{}) bool {
 
 func NewTableCheckboxPanel(ctx context.Context, parent page.ControlI) {
 	p := &TableCheckboxPanel{}
-	p.Panel.Init(p, parent, "checkboxTablePanel")
+	p.Self = p
+	p.Init(ctx, parent, "checkboxTablePanel")
+}
+
+func (p *TableCheckboxPanel) Init(ctx context.Context, parent page.ControlI, id string) {
+	p.Panel.Init(parent, "checkboxTablePanel")
 	p.AddControls(ctx,
 		PagedTableCreator{
 			ID: "table1",
@@ -77,6 +82,7 @@ func NewTableCheckboxPanel(ctx context.Context, parent page.ControlI) {
 			OnSubmit: action.Server("checkboxPanel", ButtonSubmit),
 		},
 	)
+
 }
 
 // BindData satisfies the data provider interface so that the parent panel of the table
@@ -109,7 +115,7 @@ func init() {
 	browsertest.RegisterTestFunction("Table - Checkbox Server Submit", testTableCheckboxServerSubmit)
 
 	gob.Register(SelectedProvider{}) // We must register this here because we are putting the changes map into the session,
-	page.RegisterControl(TableCheckboxPanel{})
+	page.RegisterControl(&TableCheckboxPanel{})
 }
 
 func testTableCheckboxNav(t *browsertest.TestForm) {

--- a/web/examples/controls/panels/table_db.go
+++ b/web/examples/controls/panels/table_db.go
@@ -17,7 +17,12 @@ type TableDbPanel struct {
 
 func NewTableDbPanel(ctx context.Context, parent page.ControlI) {
 	p := &TableDbPanel{}
-	p.Panel.Init(p, parent, "tableDbPanel")
+	p.Self = p
+	p.Init(ctx, parent, "tableDbPanel")
+}
+
+func (p *TableDbPanel) Init(ctx context.Context, parent page.ControlI, id string) {
+	p.Panel.Init(parent, id)
 	p.AddControls(ctx,
 		PagedTableCreator{
 			ID: "table1",
@@ -64,6 +69,7 @@ func NewTableDbPanel(ctx context.Context, parent page.ControlI) {
 			OnSubmit: action.Ajax("checkboxPanel", ButtonSubmit),
 		},
 	)
+
 }
 
 // BindData satisfies the data provider interface so that the parent panel of the table
@@ -96,5 +102,5 @@ func (p *TableDbPanel) CellText(ctx context.Context, col ColumnI, rowNum int, co
 }
 
 func init() {
-	page.RegisterControl(TableDbPanel{})
+	page.RegisterControl(&TableDbPanel{})
 }

--- a/web/examples/controls/panels/table_proxy.go
+++ b/web/examples/controls/panels/table_proxy.go
@@ -21,7 +21,13 @@ type TableProxyPanel struct {
 
 func NewTableProxyPanel(ctx context.Context, parent page.ControlI) {
 	p := &TableProxyPanel{}
-	p.Panel.Init(p, parent, "tableProxyPanel")
+	p.Self = p
+	p.Init(ctx, parent, "tableProxyPanel")
+}
+
+func (p *TableProxyPanel) Init(ctx context.Context, parent page.ControlI, id string) {
+	p.Panel.Init(parent, id)
+
 	p.AddControls(ctx,
 		ProxyCreator{
 			ID: "pxy",
@@ -104,7 +110,8 @@ type ProjectPanel struct {
 
 func NewProjectPanel(parent page.ControlI) *ProjectPanel {
 	p := &ProjectPanel{}
-	p.Init(p, parent, "personPanel")
+	p.Self = p
+	p.Init(parent, "personPanel")
 
 	return p
 }
@@ -116,8 +123,8 @@ func (p *ProjectPanel) SetProject(project *Project) {
 
 func init() {
 	browsertest.RegisterTestFunction("Table - Proxy Column", testTableProxyCol)
-	page.RegisterControl(ProjectPanel{})
-	page.RegisterControl(TableProxyPanel{})
+	page.RegisterControl(&ProjectPanel{})
+	page.RegisterControl(&TableProxyPanel{})
 }
 
 func testTableProxyCol(t *browsertest.TestForm) {

--- a/web/examples/controls/panels/table_select.go
+++ b/web/examples/controls/panels/table_select.go
@@ -21,15 +21,20 @@ type TableSelectPanel struct {
 
 
 func NewTableSelectPanel(ctx context.Context, parent page.ControlI) {
+	p := &TableSelectPanel{}
+	p.Self = p
+	p.Init(ctx, parent, "tableSelectPanel")
+}
+
+func (p *TableSelectPanel) Init(ctx context.Context, parent page.ControlI, id string) {
+	p.Panel.Init(parent, "tableSelectPanel")
+
 	// In this first example, we create a small table pre-filled with data
 	var items = []map[string]string {
 		{"id": "1", "col1": "Row 1, Col 1", "col2": "Row 1, Col 2"},
 		{"id": "2", "col1": "Row 2, Col 1", "col2": "Row 2, Col 2"},
 		{"id": "3", "col1": "Row 3, Col 1", "col2": "Row 3, Col 2"},
 	}
-
-	p := &TableSelectPanel{}
-	p.Panel.Init(p, parent, "tableSelectPanel")
 	p.AddControls(ctx,
 		SelectTableCreator{
 			ID: "table1",
@@ -85,7 +90,9 @@ func NewTableSelectPanel(ctx context.Context, parent page.ControlI) {
 	if t2 := GetSelectTable(p, "table2"); t2.SelectedID() != "" {
 		GetPanel(p, "infoPanel").SetText(fmt.Sprintf("Row %s was selected.", t2.SelectedID()))
 	}
+
 }
+
 
 // BindData satisfies the data provider interface so that the parent panel of the table
 // is the one that is providing the table.
@@ -110,6 +117,6 @@ func (p *TableSelectPanel) Action(ctx context.Context, a page.ActionParams) {
 
 
 func init() {
-	page.RegisterControl(TableSelectPanel{})
+	page.RegisterControl(&TableSelectPanel{})
 	gob.Register([]map[string]string{})
 }

--- a/web/examples/controls/panels/textbox.go
+++ b/web/examples/controls/panels/textbox.go
@@ -10,15 +10,18 @@ import (
 	"github.com/goradd/goradd/test/browsertest"
 )
 
-
-
 type TextboxPanel struct {
 	Panel
 }
 
 func NewTextboxPanel(ctx context.Context, parent page.ControlI) {
 	p := &TextboxPanel{}
-	p.Panel.Init(p, parent, "textboxPanel")
+	p.Self = p
+	p.Init(ctx, parent, "textboxPanel")
+}
+
+func (p *TextboxPanel) Init(ctx context.Context, parent page.ControlI, id string) {
+	p.Panel.Init(parent, "textboxPanel")
 
 	p.Panel.AddControls(ctx,
 		FormFieldWrapperCreator{
@@ -42,51 +45,51 @@ func NewTextboxPanel(ctx context.Context, parent page.ControlI) {
 			ID:    "intText-ff",
 			Label: "Integer Text",
 			Child: IntegerTextboxCreator{
-				ID:        "intText",
+				ID: "intText",
 			},
 		},
 		FormFieldWrapperCreator{
 			ID:    "floatText-ff",
 			Label: "Float Text",
 			Child: FloatTextboxCreator{
-				ID:        "floatText",
+				ID: "floatText",
 			},
 		},
 		FormFieldWrapperCreator{
 			ID:    "emailText-ff",
 			Label: "Email Text",
 			Child: EmailTextboxCreator{
-				ID:        "emailText",
+				ID: "emailText",
 			},
 		},
 		FormFieldWrapperCreator{
 			ID:    "passwordText-ff",
 			Label: "Password",
 			Child: TextboxCreator{
-				ID:        "passwordText",
-				Type:TextboxTypePassword,
+				ID:   "passwordText",
+				Type: TextboxTypePassword,
 			},
 		},
 		FormFieldWrapperCreator{
 			ID:    "searchText-ff",
 			Label: "Search",
 			Child: TextboxCreator{
-				ID:        "searchText",
-				Type:TextboxTypeSearch,
+				ID:   "searchText",
+				Type: TextboxTypeSearch,
 			},
 		},
 		FormFieldWrapperCreator{
 			ID:    "dateTimeText-ff",
 			Label: "U.S. Date-time",
 			Child: DateTextboxCreator{
-				ID:        "dateTimeText",
+				ID: "dateTimeText",
 			},
 		},
 		FormFieldWrapperCreator{
 			ID:    "dateText-ff",
 			Label: "Euro Date",
 			Child: DateTextboxCreator{
-				ID:        "dateText",
+				ID:     "dateText",
 				Format: datetime.EuroDate,
 			},
 		},
@@ -94,7 +97,7 @@ func NewTextboxPanel(ctx context.Context, parent page.ControlI) {
 			ID:    "timeText-ff",
 			Label: "U.S. Time",
 			Child: DateTextboxCreator{
-				ID:        "timeText",
+				ID:     "timeText",
 				Format: datetime.UsTime,
 			},
 		},
@@ -108,7 +111,6 @@ func NewTextboxPanel(ctx context.Context, parent page.ControlI) {
 			Text:     "Submit Server",
 			OnSubmit: action.Server("textboxPanel", ButtonSubmit),
 		},
-
 	)
 }
 
@@ -121,7 +123,7 @@ func (p *TextboxPanel) Action(ctx context.Context, a page.ActionParams) {
 func init() {
 	browsertest.RegisterTestFunction("Textbox Ajax Submit", testTextboxAjaxSubmit)
 	browsertest.RegisterTestFunction("Textbox Server Submit", testTextboxServerSubmit)
-	page.RegisterControl(TextboxPanel{})
+	page.RegisterControl(&TextboxPanel{})
 }
 
 func testTextboxAjaxSubmit(t *browsertest.TestForm) {
@@ -170,7 +172,7 @@ func testTextboxSubmit(t *browsertest.TestForm, btnID string) {
 	t.AssertEqual(true, t.HasClass("timeText-ff", "error"))
 	t.AssertEqual(true, t.HasClass("dateTimeText-ff", "error"))
 
-	t.F(func (f page.FormI) {
+	t.F(func(f page.FormI) {
 		GetFormFieldWrapper(f, "plainText-ff").SetInstructions("Sample instructions")
 	})
 	t.ChangeVal("intText", 5)
@@ -182,7 +184,7 @@ func testTextboxSubmit(t *browsertest.TestForm, btnID string) {
 
 	t.Click(btnID)
 
-	t.F(func (f page.FormI) {
+	t.F(func(f page.FormI) {
 		t.AssertEqual(5, GetIntegerTextbox(f, "intText").Int())
 		t.AssertEqual(6.7, GetFloatTextbox(f, "floatText").Float64())
 		t.AssertEqual("me@you.com", GetEmailTextbox(f, "emailText").Text())
@@ -190,7 +192,6 @@ func testTextboxSubmit(t *browsertest.TestForm, btnID string) {
 		t.AssertEqual(datetime.NewDateTime("4:59 am", datetime.UsTime), GetDateTextbox(f, "timeText").Date())
 		t.AssertEqual(datetime.NewDateTime("2/19/2018 4:23 pm", datetime.UsDateTime), GetDateTextbox(f, "dateTimeText").Date())
 	})
-
 
 	t.AssertEqual(false, t.HasClass("intText-ff", "error"))
 	t.AssertEqual(false, t.HasClass("floatText-ff", "error"))
@@ -203,9 +204,8 @@ func testTextboxSubmit(t *browsertest.TestForm, btnID string) {
 	t.AssertEqual("plainText-ff_lbl plainText", t.ControlAttribute("plainText", "aria-labelledby"))
 
 	// Test SaveState
-	t.F(func (f page.FormI) {
+	t.F(func(f page.FormI) {
 		t.AssertEqual("me", GetTextbox(f, "plainText").Text())
 	})
-
 
 }

--- a/web/examples/tutorial/default.go
+++ b/web/examples/tutorial/default.go
@@ -13,10 +13,11 @@ type DefaultPanel struct {
 
 func NewDefaultPanel(ctx context.Context, parent page.ControlI)  {
 	p := &DefaultPanel{}
-	p.Panel.Init(p, parent, "defaultPanel")
+	p.Self = p
+	p.Panel.Init(parent, "defaultPanel")
 }
 
 
 func init() {
-	page.RegisterControl(DefaultPanel{})
+	page.RegisterControl(&DefaultPanel{})
 }

--- a/web/examples/tutorial/filePanel.go
+++ b/web/examples/tutorial/filePanel.go
@@ -15,7 +15,8 @@ type FilePanel struct {
 
 func NewFilePanel(parent page.ControlI) *FilePanel {
 	p := &FilePanel{}
-	p.Panel.Init(p, parent, "filePanel")
+	p.Self = p
+	p.Panel.Init(parent, "filePanel")
 	return p
 }
 
@@ -26,7 +27,7 @@ func (p *FilePanel) SetFile(f string) {
 }
 
 func init() {
-	page.RegisterControl(FilePanel{})
+	page.RegisterControl(&FilePanel{})
 }
 
 // TODO: Serialize

--- a/web/examples/tutorial/index.go
+++ b/web/examples/tutorial/index.go
@@ -25,9 +25,8 @@ type IndexForm struct {
 }
 
 
-func NewIndexForm(ctx context.Context) page.FormI {
-	f := &IndexForm{}
-	f.Init(ctx, f, IndexFormPath, IndexFormId)
+func (f *IndexForm) Init(ctx context.Context, formID string) {
+	f.FormBase.Init(ctx, formID)
 	f.AddRelatedFiles()
 
 	f.AddControls(ctx,
@@ -40,8 +39,6 @@ func NewIndexForm(ctx context.Context) page.FormI {
 			OnClick: action.Ajax(f.ID(), ViewSourceAction),
 		},
 	)
-
-	return f
 }
 
 func (f *IndexForm) AddRelatedFiles() {
@@ -104,7 +101,6 @@ func (f *IndexForm) Action(ctx context.Context, a page.ActionParams) {
 
 
 func init() {
-	page.RegisterPage(IndexFormPath, NewIndexForm, IndexFormId)
-	page.RegisterControl(IndexForm{})
+	page.RegisterForm(IndexFormPath, &IndexForm{}, IndexFormId)
 }
 

--- a/web/examples/tutorial/orm/0-intro.go
+++ b/web/examples/tutorial/orm/0-intro.go
@@ -15,13 +15,18 @@ type IntroPanel struct {
 
 func NewIntroPanel(ctx context.Context, parent page.ControlI) page.ControlI {
 	p := &IntroPanel{}
-	p.Panel.Init(p, parent, "")
+	p.Self = p
+	p.Init(ctx, parent, "")
 	return p
+}
+
+func (p *IntroPanel) Init(ctx context.Context, parent page.ControlI, id string) {
+	p.Panel.Init(parent, id)
 }
 
 
 func init() {
-	page.RegisterControl(IntroPanel{})
+	page.RegisterControl(&IntroPanel{})
 
 	dir := sys.SourceDirectory()
 	tutorial.RegisterTutorialPage("orm", 0, "intro", "Introduction to the ORM", NewIntroPanel,

--- a/web/examples/tutorial/orm/1-objects.go
+++ b/web/examples/tutorial/orm/1-objects.go
@@ -15,13 +15,18 @@ type ObjectsPanel struct {
 
 func NewObjectsPanel(ctx context.Context, parent page.ControlI) page.ControlI {
 	p := &ObjectsPanel{}
-	p.Panel.Init(p, parent, "")
+	p.Self = p
+	p.Init(ctx, parent, "")
 	return p
+}
+
+func (p *ObjectsPanel) Init(ctx context.Context, parent page.ControlI, id string) {
+	p.Panel.Init(parent, id)
 }
 
 
 func init() {
-	page.RegisterControl(ObjectsPanel{})
+	page.RegisterControl(&ObjectsPanel{})
 
 	dir := sys.SourceDirectory()
 	tutorial.RegisterTutorialPage("orm", 1, "objects", "Code-generated objects", NewObjectsPanel,

--- a/web/examples/tutorial/orm/2-load.go
+++ b/web/examples/tutorial/orm/2-load.go
@@ -15,13 +15,18 @@ type LoadPanel struct {
 
 func NewLoadPanel(ctx context.Context, parent page.ControlI) page.ControlI {
 	p := &LoadPanel{}
-	p.Panel.Init(p, parent, "")
+	p.Self = p
+	p.Init(ctx, parent, "")
 	return p
+}
+
+func (p *LoadPanel) Init(ctx context.Context, parent page.ControlI, id string) {
+	p.Panel.Init(parent, id)
 }
 
 
 func init() {
-	page.RegisterControl(LoadPanel{})
+	page.RegisterControl(&LoadPanel{})
 
 	dir := sys.SourceDirectory()
 	tutorial.RegisterTutorialPage("orm", 2, "load", "Loading Individual Records", NewLoadPanel,

--- a/web/examples/tutorial/orm/3-query.go
+++ b/web/examples/tutorial/orm/3-query.go
@@ -15,13 +15,18 @@ type QueryPanel struct {
 
 func NewQueryPanel(ctx context.Context, parent page.ControlI) page.ControlI {
 	p := &QueryPanel{}
-	p.Panel.Init(p, parent, "")
+	p.Self = p
+	p.Init(ctx, parent, "")
 	return p
+}
+
+func (p *QueryPanel) Init(ctx context.Context, parent page.ControlI, id string) {
+	p.Panel.Init(parent, id)
 }
 
 
 func init() {
-	page.RegisterControl(QueryPanel{})
+	page.RegisterControl(&QueryPanel{})
 
 	dir := sys.SourceDirectory()
 	tutorial.RegisterTutorialPage("orm", 3, "query", "Querying the Database Using a QueryBuilder", NewQueryPanel,

--- a/web/examples/tutorial/orm/4-crud.go
+++ b/web/examples/tutorial/orm/4-crud.go
@@ -15,13 +15,18 @@ type CrudPanel struct {
 
 func NewCrudPanel(ctx context.Context, parent page.ControlI) page.ControlI {
 	p := &CrudPanel{}
-	p.Panel.Init(p, parent, "")
+	p.Self = p
+	p.Init(ctx, parent, "")
 	return p
+}
+
+func (p *CrudPanel) Init(ctx context.Context, parent page.ControlI, id string) {
+	p.Panel.Init(parent, id)
 }
 
 
 func init() {
-	page.RegisterControl(CrudPanel{})
+	page.RegisterControl(&CrudPanel{})
 
 	dir := sys.SourceDirectory()
 	tutorial.RegisterTutorialPage("orm", 3, "crud", "Creating, Modifying and Deleting Database Objects", NewCrudPanel,

--- a/web/examples/tutorial/orm/5-ref.go
+++ b/web/examples/tutorial/orm/5-ref.go
@@ -15,13 +15,17 @@ type RefPanel struct {
 
 func NewRefPanel(ctx context.Context, parent page.ControlI) page.ControlI {
 	p := &RefPanel{}
-	p.Panel.Init(p, parent, "")
+	p.Self = p
+	p.Init(ctx, parent, "")
 	return p
 }
 
+func (p *RefPanel) Init(ctx context.Context, parent page.ControlI, id string) {
+	p.Panel.Init(parent, id)
+}
 
 func init() {
-	page.RegisterControl(RefPanel{})
+	page.RegisterControl(&RefPanel{})
 
 	dir := sys.SourceDirectory()
 	tutorial.RegisterTutorialPage("orm", 3, "ref", "References", NewRefPanel,

--- a/web/examples/tutorial/sourcePanel.go
+++ b/web/examples/tutorial/sourcePanel.go
@@ -23,12 +23,15 @@ type SourcePanel struct {
 
 func NewSourcePanel(parent page.ControlI, id string) *SourcePanel {
 	p := &SourcePanel{}
-	p.Panel.Init(p, parent, id)
-	p.ButtonPanel = NewPanel(p, "buttonPanel")
-
-	p.FilePanel = NewFilePanel(p) // we will be doing our own escaping
-
+	p.Self = p
+	p.Init(parent, id)
 	return p
+}
+
+func (p *SourcePanel) Init(parent page.ControlI, id string) {
+	p.Panel.Init(parent, id)
+	p.ButtonPanel = NewPanel(p, "buttonPanel")
+	p.FilePanel = NewFilePanel(p) // we will be doing our own escaping
 }
 
 // show shows the panel and loads the button bar with buttons
@@ -54,7 +57,7 @@ func (p *SourcePanel) Action(ctx context.Context, a page.ActionParams) {
 
 
 func init() {
-	page.RegisterControl(SourcePanel{})
+	page.RegisterControl(&SourcePanel{})
 }
 
 func GetSourcePanel(p page.ControlI) *SourcePanel {

--- a/web/welcome/codegen_form.go
+++ b/web/welcome/codegen_form.go
@@ -20,13 +20,10 @@ type CodegenForm struct {
 	control.FormBase
 }
 
-func NewCodegenForm(ctx context.Context) page.FormI {
-	f := new(CodegenForm)
-	f.Init(ctx, f, CodegenPath, CodegenID)
+func (f *CodegenForm) Init(ctx context.Context, formID string) {
+	f.FormBase.Init(ctx, formID)
 	f.AddRelatedFiles()
 	f.createControls(ctx)
-
-	return f
 }
 
 func (f *CodegenForm) createControls(ctx context.Context) {
@@ -82,5 +79,5 @@ func (f *CodegenForm) startApp() string {
 }
 
 func init() {
-	page.RegisterPage(CodegenPath, NewCodegenForm, CodegenID)
+	page.RegisterForm(CodegenPath, &CodegenForm{}, CodegenID)
 }


### PR DESCRIPTION
Simplifying the interface for creating forms and controls. Removing the "self" parameter that gets passed everywhere in favor of an explicit setting of the variable when the object is created.