### PR TITLE
Cache buster

### DIFF
--- a/internal/install/goradd-project/web/app/app.go
+++ b/internal/install/goradd-project/web/app/app.go
@@ -45,18 +45,18 @@ func (a *Application) SetupErrorPageTemplate() {
 
 // Uncomment and edit to change the page cache. You can call the embedded Application version first, and then alter it too.
 /*
-func (a *Application) SetupPageCaching() {
+func (a *Application) SetupPagestateCaching() {
 	// Controls how pages are cached. This will vary depending on whether you are using multiple machines to run your app,
 	// and whether you are in development mode, etc.
 
 	// This default is for an in-memory store on one server and only one
 	// process on that server. It basically does not serialize anything and leaves the entire formstate intact in memory.
 	// This makes for a very fast server, but one that takes up quite a bit of RAM if you have a lot of simultaneous users.
-	page.SetPageCache(page.NewFastPageCache())
+	page.SetPagestateCache(page.NewFastPageCache())
 
 	// comment out the above, and uncomment below to change to a serialized page cache. It is still
 	// in memory, but can be used to test whether the page cache could be stored in a database instead.
-	//page.SetPageCache(page.NewSerializedPageCache(100, 60*60*24))
+	//page.SetPagestateCache(page.NewSerializedPageCache(100, 60*60*24))
 
 	// Controls how pages are serialized if a serialization cache is being used. This version uses the gob encoder.
 	// You likely will not need to change this, but you might if your database cannot handle binary data.

--- a/internal/travis/goradd-test/main.go
+++ b/internal/travis/goradd-test/main.go
@@ -27,7 +27,7 @@ func main() {
 	mux := a.MakeServerMux()
 
 	// Make sure we always test with serialization turned on so that serialization is tested during the travis tests
-	page.SetPageCache(page.NewSerializedPageCache(100, 60*60*24))
+	page.SetPagestateCache(page.NewSerializedPageCache(100, 60*60*24))
 
 	err = http.ListenAndServe(":8000", mux)
 	if err != nil {

--- a/pkg/bootstrap/control/modal.go
+++ b/pkg/bootstrap/control/modal.go
@@ -14,9 +14,9 @@ import (
 type ModalBackdropType int
 
 const (
-	ModalBackdrop ModalBackdropType = iota
-	ModalNoBackdrop
-	ModalStaticBackdrop
+	ModalBackdrop ModalBackdropType = iota		// Standard bootstrap backdrop. Clicking the backdrop closes the modal.
+	ModalNoBackdrop							    // No backdrop
+	ModalStaticBackdrop							// Clicking the backdrop will not close the modal.
 )
 
 type ModalI interface {

--- a/pkg/config/app.go
+++ b/pkg/config/app.go
@@ -24,3 +24,7 @@ var IdleTimeout = 180 * time.Second
 // dialog on the screen telling the user to refresh the page to re-establish the connection. This only happens in release
 // mode so that you don't have to worry about timeouts when debugging ajax code.
 var AjaxTimeout = 10000;
+
+// CacheBuster maps paths to checksums that are used to tell the browser when its time to reload a resource
+var CacheBuster map[string]string
+var CacheBusterPrefix = "gr."

--- a/pkg/config/form.go
+++ b/pkg/config/form.go
@@ -14,7 +14,7 @@ var Minify bool = !Debug
 var assetDirectory string
 var htmlDirectory string
 
-// AliasPath is the url path to the application. By default, this is the root, but you can set it
+// ProxyPath is the url path to the application. By default, this is the root, but you can set it
 // to any path. This is particularly useful to making the application appear as if it is running in a subdirectory
 // of the root path. This is great for putting behind an Apache server, and using ProxyPass and ProxyPassReverse to direct
 // traffic from a particular path to the application. This gets stripped off incoming urls automatically by the server,

--- a/pkg/page/asset_server.go
+++ b/pkg/page/asset_server.go
@@ -16,53 +16,6 @@ import (
 var assetDirectories = map[string]string{}
 var cacheControl = map[string]string{}
 
-// RenderAssetTag will render a tag that points to a static file asset that should be served by the MUX. filePath points
-// to the file on the development server, and it will be copied to the appropriate subdirectory in the local assets directory
-// for easy deployment. tag is the tag label to put in the tag, and attributes are additional attributes to include in the tag.
-// The copied location of the file and structure of the tag will be deduced from the type of tag and the label of the file.
-// The type of tag will also be used to automatically insert the location of the file into the correct tag attribute.
-/*
-func RenderAssetTag(filePath string, tag string, attributes html.Attributes, content string) string {
-	var typ string
-
-	_,fileName := filepath.Split(filePath)
-	ext := path.Ext(fileName)
-
-
-	switch ext {
-	case "js": fallthrough
-	case "javascript":
-		typ = "js"
-	case "css":
-		typ = "css"
-	case "jpg": fallthrough
-	case "jpeg":fallthrough
-	case "png": fallthrough
-	case "gif": fallthrough
-	case "bmp": fallthrough
-	case "ico":
-		typ = "img"
-	default:
-		switch tag {
-		case "script":
-			typ = "js"
-		case "a":
-			typ = "file" // a download file type likely, if we haven't already recognized it as something else.
-		default:
-			panic ("Unknown file type")
-		}
-	}
-
-	url := "/" + typ + "/" + fileName
-
-	url = RegisterAssetFile(url, filePath)
-
-	switch tag {
-	case script
-	}
-}
-*/
-
 // GetAssetLocation returns the disk location of the asset file indicated by the given url.
 // Asset directories must be registered with the RegisterAssetDirectory function. In debug mode, the
 // file is taken from the registered location, but in release mode, the file will have been copied to
@@ -73,16 +26,8 @@ func GetAssetLocation(url string) string {
 		if !strings2.StartsWith(url, config.AssetPrefix) {
 			panic("Assets must start with the asset prefix.")
 		}
-		fPath := strings.TrimPrefix(url, config.AssetPrefix)
-		dir,f := path.Split(fPath)
-		if len(dir) > 1 {
-
-			dir2,f2 := path.Split(dir[:len(dir) - 1])
-			// ignore the cache buster
-			if strings2.StartsWith(f2, config.CacheBusterPrefix) {
-				fPath = path.Join(dir2, f)
-			}
-		}
+		fPath := StripCacheBusterPath(url)
+		fPath = strings.TrimPrefix(fPath, config.AssetPrefix)
 		return filepath.Join(config.AssetDirectory(), filepath.Clean(fPath))
 	}
 	for dirUrl, dir := range assetDirectories {
@@ -98,11 +43,22 @@ func GetAssetLocation(url string) string {
 // GetAssetLocation.
 func GetAssetUrl(location string) string {
 	var outPath string
-	if config.Release {
-		if !strings2.StartsWith(location, config.AssetPrefix) {
-			panic("In the release build, asset locations should be the same as asset paths. " + location + " does not start with " + config.AssetPrefix)
+	if config.AssetDirectory() != "" {
+		if config.Release {
+			if !strings2.StartsWith(location, config.AssetPrefix) {
+				panic("In the release build, asset locations should be the same as asset paths. " + location + " does not start with " + config.AssetPrefix)
+			}
+		} else {
+			// debug build, but a given asset directory.
+			for url, dir := range assetDirectories {
+				if strings2.StartsWith(location, dir) {
+					fPath := strings.TrimPrefix(location, dir)
+					location = path.Join(url, filepath.ToSlash(fPath))
+					break
+				}
+			}
 		}
-		outPath = location
+		outPath = CacheBustedPath(location)
 	} else {
 		for url, dir := range assetDirectories {
 			if strings2.StartsWith(location, dir) {
@@ -216,7 +172,7 @@ func ServeAsset(w http.ResponseWriter, r *http.Request) {
 }
 
 // RegisterAssetDirectory registers the given directory as a static file server. The files are served by the normal
-// go static file process. This must happen during application initialization, as the static file directories
+// go static file process. RegisterAssetDirectory must be called during application initialization, as the static file directories
 // are added to the MUX at startup time.
 func RegisterAssetDirectory(dir string, pattern string) {
 	if d, ok := assetDirectories[pattern]; ok && d != dir {
@@ -234,3 +190,27 @@ func SetCacheControl(path string, cacheControlSetting string) {
 	url := GetAssetUrl(path)
 	cacheControl[url] = cacheControlSetting
 }
+
+// CacheBustedPath returns a path to an asset that was previously registered with the CacheBuster. The new path
+// will contain a hash of the file that will change whenever the file changes, and cause the browser to reload the file.
+// Since we are in control of serving these files, we will later remove the hash before serving it.
+func CacheBustedPath(url string) string {
+	if p,ok := config.CacheBuster[url]; ok {
+		// inject the crc as a part of the path.
+		dir,file := path.Split(url)
+		url = path.Join(dir, config.CacheBusterPrefix + p, file)
+	}
+	return url
+}
+
+// StripCacheBusterPath removes the hash of the asset file from the path to the asset.
+func StripCacheBusterPath(fPath string) string {
+	dir,f := path.Split(fPath)
+	dir2,f2 := path.Split(dir[:len(dir) - 1]) // ignore trailing slash
+	// ignore the cache buster
+	if strings2.StartsWith(f2, config.CacheBusterPrefix) {
+		fPath = path.Join(dir2, f)
+	}
+	return fPath
+}
+

--- a/pkg/page/asset_server.go
+++ b/pkg/page/asset_server.go
@@ -14,7 +14,6 @@ import (
 )
 
 var assetDirectories = map[string]string{}
-var cacheControl = map[string]string{}
 
 // GetAssetLocation returns the disk location of the asset file indicated by the given url.
 // Asset directories must be registered with the RegisterAssetDirectory function. In debug mode, the
@@ -104,10 +103,6 @@ func ServeAsset(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate, max-age=1")
 		http.ServeFile(w, r, localpath)
 	} else {
-		if cc,ok := cacheControl[r.URL.Path]; ok {
-			w.Header().Set("Cache-Control", cc)
-		}
-
 		var ext = filepath.Ext(localpath)
 
 		var minFileName string
@@ -181,15 +176,6 @@ func RegisterAssetDirectory(dir string, pattern string) {
 	assetDirectories[pattern] = dir
 }
 
-// SetCacheControl sets the cache control setting for the given asset file.
-//
-// Do this only during application initialization, since we are not using a mutex.
-//
-// path is the directory path to the file on the development server, the same you use to register the file.
-func SetCacheControl(path string, cacheControlSetting string) {
-	url := GetAssetUrl(path)
-	cacheControl[url] = cacheControlSetting
-}
 
 // CacheBustedPath returns a path to an asset that was previously registered with the CacheBuster. The new path
 // will contain a hash of the file that will change whenever the file changes, and cause the browser to reload the file.

--- a/pkg/page/form_base.go
+++ b/pkg/page/form_base.go
@@ -15,7 +15,6 @@ import (
 	"github.com/goradd/goradd/pkg/orm/db"
 	"github.com/goradd/goradd/pkg/session"
 	"github.com/goradd/goradd/pkg/session/location"
-	path2 "path"
 	"path/filepath"
 	"strings"
 )
@@ -40,7 +39,6 @@ type FormI interface {
 	ChangeLocation(url string)
 	PushLocation(ctx context.Context)
 	PopLocation(ctx context.Context, fallback string)
-	CacheBustedPath(string) string
 
 	// Lifecycle calls
 	Run(ctx context.Context) error
@@ -447,7 +445,6 @@ func (f *FormBase) DrawHeaderTags(ctx context.Context, buf *bytes.Buffer) {
 				attributes = html.NewAttributes()
 			}
 			attributes.Set("rel", "stylesheet")
-			path = f.this().CacheBustedPath(path)
 			attributes.Set("href", path)
 			buf.WriteString(html.RenderVoidTag("link", attributes))
 			return true
@@ -460,7 +457,6 @@ func (f *FormBase) DrawHeaderTags(ctx context.Context, buf *bytes.Buffer) {
 			if attributes == nil {
 				attributes = html.NewAttributes()
 			}
-			path = f.this().CacheBustedPath(path)
 			attributes.Set("src", path)
 			buf.WriteString(html.RenderTag("script", attributes, ""))
 			return true
@@ -492,7 +488,6 @@ func (f *FormBase) drawBodyScriptFiles(ctx context.Context, buf *bytes.Buffer) {
 		if attributes == nil {
 			attributes = html.NewAttributes()
 		}
-		path = f.this().CacheBustedPath(path)
 		attributes.Set("src", path)
 		buf.WriteString(html.RenderTag("script", attributes, "") + "\n")
 		return true
@@ -500,14 +495,6 @@ func (f *FormBase) drawBodyScriptFiles(ctx context.Context, buf *bytes.Buffer) {
 
 }
 
-func (f *FormBase) CacheBustedPath(path string) string {
-	if p,ok := config.CacheBuster[path]; ok {
-		// inject the crc as a part of the path
-		dir,file := path2.Split(path)
-		path = path2.Join(dir, config.CacheBusterPrefix + p, file)
-	}
-	return path
-}
 
 // DisplayAlert will display a javascript alert with the given message.
 func (f *FormBase) DisplayAlert(ctx context.Context, msg string) {

--- a/pkg/page/static_file_server.go
+++ b/pkg/page/static_file_server.go
@@ -74,6 +74,15 @@ func GetAssetLocation(url string) string {
 			panic("Assets must start with the asset prefix.")
 		}
 		fPath := strings.TrimPrefix(url, config.AssetPrefix)
+		dir,f := path.Split(fPath)
+		if len(dir) > 1 {
+
+			dir2,f2 := path.Split(dir[:len(dir) - 1])
+			// ignore the cache buster
+			if strings2.StartsWith(f2, config.CacheBusterPrefix) {
+				fPath = path.Join(dir2, f)
+			}
+		}
 		return filepath.Join(config.AssetDirectory(), filepath.Clean(fPath))
 	}
 	for dirUrl, dir := range assetDirectories {

--- a/test/browsertest/test_form.go
+++ b/test/browsertest/test_form.go
@@ -133,8 +133,8 @@ func (form *TestForm) LoadUrl(url string)  {
 
 // getForm returns the currently loaded form.
 func (form *TestForm) getForm() page.FormI {
-	if page.GetPageCache().Has(form.Controller.pagestate) {
-		pc := page.GetPageCache()
+	if page.GetPagestateCache().Has(form.Controller.pagestate) {
+		pc := page.GetPagestateCache()
 		/*if loader,ok := pc.(GetLoader); ok {
 			p := loader.GetLoaded(form.Controller.pagestate)
 			f :=  p.Form()
@@ -149,7 +149,7 @@ func (form *TestForm) getForm() page.FormI {
 // Call it with a function that will receive the form.
 // Do not call test functions that might cause an ajax or server call to fire from within the function.
 func (form *TestForm) WithForm(f func(page.FormI) ) {
-	pc := page.GetPageCache()
+	pc := page.GetPagestateCache()
 	testForm := pc.Get(form.Controller.pagestate).Form()
 	{
 		form.usingForm = true
@@ -374,8 +374,8 @@ func (form *TestForm) captureCaller() string {
 
 // GetTestForm returns the test form itself, if its loaded
 func GetTestForm() page.FormI {
-	if page.GetPageCache().Has(testFormPageState) {
-		return page.GetPageCache().Get(testFormPageState).Form()
+	if page.GetPagestateCache().Has(testFormPageState) {
+		return page.GetPagestateCache().Get(testFormPageState).Form()
 	}
 	return nil
 }

--- a/web/app/app_base.go
+++ b/web/app/app_base.go
@@ -137,15 +137,13 @@ func (a *Application) SetupCacheBuster() {
 	t := crc64.MakeTable(crc64.ECMA)
 	config.CacheBuster = make (map[string]string)
 	assetDir := config.AssetDirectory()
+	if assetDir == "" {return}
 	if err := filepath.Walk(assetDir, func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() {
-			if err != nil {
-				return filepath.SkipDir // don't read this directory
-			}
-			return nil // keep going
-		}
 		if err != nil {
-			return nil // skip this file
+			return err // stop
+		}
+		if info.IsDir() {
+			return nil // keep going
 		}
 		if filepath.Ext(path) == ".gz" {
 			// skip encrypted files, since they will be handled automatically

--- a/web/app/app_base.go
+++ b/web/app/app_base.go
@@ -52,7 +52,7 @@ type staticFileProcessor struct {
 type StaticFileProcessorFunc func(file string, w http.ResponseWriter, r *http.Request)
 
 // StaticFileProcessors is a map that connects file endings to processors that will process the content and return it
-// to the output stream, bypassing other means of prcessing static files.
+// to the output stream, bypassing other means of processing static files.
 var staticFileProcessors []staticFileProcessor
 
 // The application interface. A minimal set of commands that the main routine will ask the application to do.
@@ -401,7 +401,7 @@ func (a *Application) ServeStaticFile(w http.ResponseWriter, r *http.Request) bo
 	})
 
 	if path == "" {
-		return false // not found
+		return false // the directory was not found in our list of static file directories
 	}
 
 	for _, bl := range StaticBlacklist {


### PR DESCRIPTION
Implementing a cache busting strategy so that all asset files can be cached by the browser, but when they change, they are automatically fetched. This happens without the browser having to ask the server if each file has changed.