### PR TITLE
Nil value was creating a <nil> string

### DIFF
--- a/pkg/page/control/list_select.go
+++ b/pkg/page/control/list_select.go
@@ -122,6 +122,9 @@ func (l *SelectList) Value() interface{} {
 
 // SetValue implements the Valuer interface for general purpose value getting and setting
 func (l *SelectList) SetValue(v interface{}) {
+	if v == nil {
+		v = ""
+	}
 	l.SetSelectedValue(fmt.Sprint(v))
 }
 


### PR DESCRIPTION
Fixes a problem that would eventually cause an unexpected problem in the database.