### PR TITLE
Moving logging initialization

### DIFF
--- a/doc/embedder.go
+++ b/doc/embedder.go
@@ -1,7 +1,5 @@
+// Package doc contains documentation as Markdown files for the
 package doc
-
-// This file causes the directory to be served up as a static file directory.
-// To make this happen, the main application just needs to import it.
 
 import (
 	"embed"
@@ -22,7 +20,7 @@ func init() {
 
 // serveMarkdown converts markdown files to html and serves them.
 // This would be more efficient if they were preprocessed into html files and served as html,
-// but this is an example of how live processing of files can be done.
+// but this is an example of how to process text files.
 func serveMarkdown(r io.Reader, w http.ResponseWriter, req *http.Request) error {
 	markdown, err := io.ReadAll(r)
 	if err != nil {

--- a/internal/install/goradd-project/config/log.go
+++ b/internal/install/goradd-project/config/log.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"github.com/goradd/goradd/pkg/config"
+	grlog "github.com/goradd/goradd/pkg/log"
+	"log"
+	"os"
+)
+
+// initLogs initializes the loggers for the various levels of logging in the app.
+// You can specify a different logging behavior from here depending on whether it
+// is a development or release build.
+func initLogs() {
+	if !config.Release {
+		// Development build
+		grlog.CreateDefaultLoggers()
+	} else {
+		grlog.SetLogger(grlog.ErrorLog, grlog.StandardLogger{log.New(os.Stderr,
+			"Error:     ", log.Ldate|log.Lmicroseconds|log.Llongfile)})
+	}
+}

--- a/internal/install/goradd-project/config/setup.go
+++ b/internal/install/goradd-project/config/setup.go
@@ -4,6 +4,7 @@ package config
 // We can make sure this gets called first by importing config with an underscore
 
 func init() {
+	initLogs()
 	initDatabases()
 	initGoradd()
 	initApp()

--- a/internal/install/goradd-project/web/app/app.go
+++ b/internal/install/goradd-project/web/app/app.go
@@ -50,22 +50,6 @@ func (a *Application) SetupPagestateCaching() {
 }
 */
 
-// InitializeLoggers allows you to set up the various types of logs for various types of builds. By default, the DebugLog
-// and FrameworkDebugLogs will be deactivated when the config.Debug variables are false. Otherwise, configure how you
-// want, and simply remove a log if you don't want it to log anything.
-/*
-func (a *Application) InitializeLoggers() {
-	a.Application.InitializeLoggers()
-
-	// This example turns the error log into an email logger in release mode so we will be notified when errors
-	// occur on our production server
-	if config.Release {
-		log2.Loggers[log2.ErrorLog] = log2.EmailLogger{log.New(os.Stdout,
-		"Error: ", log.Ldate|log.Lmicroseconds|log.Lshortfile), []string{"errors@mybusiness.com", "supervisor@mybusiness.com"}}
-	}
-}
-*/
-
 // SetupMessenger injects the global messenger that permits pub/sub communication between the server and client.
 // Uncomment the following if you need to change parameters on the hub.
 // If you don't need this at all, you can uncomment below and simply make it an empty function.

--- a/pkg/config/app.go
+++ b/pkg/config/app.go
@@ -10,20 +10,24 @@ var HSTSTimeout int64 = 86400 // one day
 // It helps prevent an attack where the client opens a connection and then sends us data really slowly.
 // See go's http package, server.go for details.
 var ReadTimeout = 20 * time.Second
+
 // ReadHeaderTimeout specifies the time that a client has to complete sending us its headers. See go's http package, server.go for details.
 // This can be used to control per request read timeouts. If zero, ReadTimeout is used.
 var ReadHeaderTimeout = 0 * time.Second
+
 // WriteTimeout is the amount of time our server will wait for our app to finish writing the response. It helps prevent
 // an attack where the server makes a request, but then reads the response very slowly.
 var WriteTimeout = 20 * time.Second
-// IdleTimout is used during keep-alive connections to control how often the client must ping us to keep the connection alive.
+
+// IdleTimeout is used during keep-alive connections to control how often the client must ping us to keep the connection alive.
 // It helps us detect whether the client has gone away so that we can then close the connection.
 var IdleTimeout = 180 * time.Second
+
 // AjaxTimeout is the amount of time in milliseconds that we direct the browser to wait until it determines that an ajax
 // call timed out. This would mean that the browser has lost the connection to the server. The goradd.js file put up a
 // dialog on the screen telling the user to refresh the page to re-establish the connection. This only happens in release
 // mode so that you don't have to worry about timeouts when debugging ajax code.
-var AjaxTimeout = 10000;
+var AjaxTimeout = 10000
 
 // CacheBusterPrefix is a fragment that is included with cache busted paths.
 var CacheBusterPrefix = "gr."
@@ -34,5 +38,7 @@ var TLSPort int = 0 // This will require ssl certificates. The default has this 
 
 // You will need to put in the path to your certfile and keyfile below.
 // The default implementation only uses these for the release build.
+
+// TLSCertFile is the path for the https certificate. By default, it is only used in the release build.
 var TLSCertFile = ""
 var TLSKeyFile = ""

--- a/pkg/config/buildDebug.go
+++ b/pkg/config/buildDebug.go
@@ -1,4 +1,4 @@
-// +build !nodebug
+//go:build !nodebug
 
 package config
 

--- a/pkg/config/buildDev.go
+++ b/pkg/config/buildDev.go
@@ -1,4 +1,4 @@
-// +build !release
+//go:build !release
 
 package config
 

--- a/pkg/config/buildNoDebug.go
+++ b/pkg/config/buildNoDebug.go
@@ -1,4 +1,4 @@
-// +build nodebug
+//go:build nodebug
 
 package config
 

--- a/pkg/config/buildRelease.go
+++ b/pkg/config/buildRelease.go
@@ -1,5 +1,4 @@
 //go:build release
-// +build release
 
 package config
 


### PR DESCRIPTION
Moving logger initialization to the project config package so that logging can be controlled during init time, and its more apparent how to customize the logging process.

This is a breaking change. Previous apps will need to add logging initialization to the config package.