### PR TITLE
Moving globals

### DIFF
--- a/internal/install/goradd-project/config/app.go
+++ b/internal/install/goradd-project/config/app.go
@@ -1,7 +1,34 @@
 package config
 
-// This is space to put your apps own config constants and variables
+import "github.com/goradd/goradd/pkg/config"
+
+// The variables below are initialized from the main() function. Delete whatever you don't need.
+
+// Port is the http port the app will run on. If not set, it will use the default of 80.
+var Port int = 0
+
+// The following variables are needed only if you are serving secure communications directly from the application.
+// You can alternatively put the application behind a reverse proxy provided by apache or nginx and let those
+// applications handle the encryption layer. See the build/docker/docker-compose.yml files for more info.
+
+// TLSPort is the port to serve SSL from. If this is unset, it will not serve SSL. If set, you must also
+// provide a TLSCertFile and TLSKeyFile below.
+var TLSPort int = 0
+
+// TLSCertFile is the path for the https certificate.
+var TLSCertFile = ""
+
+// TLSKeyFile is the path to the https key file.
+var TLSKeyFile = ""
+
+// This is space to put your apps own config constants and variables, or modify globals as needed.
 
 func initApp() {
+	if !config.Release {
+		// Put initializations here just for the development build
+	} else {
+		// Put initializations here for the release build
+	}
 
+	// Put initializations here for all builds
 }

--- a/internal/install/goradd-project/config/goradd.go
+++ b/internal/install/goradd-project/config/goradd.go
@@ -6,9 +6,9 @@ import (
 	"runtime"
 )
 
-func initGoradd() {
-	setupPorts()
+// This file is for code that changes global variables that are part of the GoRADD framework.
 
+func initGoradd() {
 	setupDateFormats()
 	setupTranslator()
 	//setupBootstrap()
@@ -27,22 +27,8 @@ func initGoradd() {
 
 	//config.ApiPrefix = "/myapi" // Uncomment this to change the prefix for api calls (aka REST calls). The default is "/api".
 	//config.WebsocketMessengerPrefix = "/ws/" // Sets the websocket messenger prefix. Set to blank to turn off the websocket messenger.
-												// Otherwise, set to whatever prefix will not conflict with the rest of your app.
+	// Otherwise, set to whatever prefix will not conflict with the rest of your app.
 
-}
-
-// setupPorts gives you an opportunity to hardcode the port values and certificate locations in your app.
-// you can also put these on the command line
-func setupPorts() {
-	/*
-		config.Port = 8000
-		config.TLSPort = 8001 // This will require ssl certificates.
-
-		// You will need to put in the path to your certfile and keyfile below.
-		// The default implementation only uses these for the release build.
-		config.TLSCertFile = ""
-		config.TLSKeyFile = ""
-	*/
 }
 
 func setupDateFormats() {

--- a/internal/install/goradd-project/main/devInclude.go
+++ b/internal/install/goradd-project/main/devInclude.go
@@ -1,5 +1,4 @@
 //go:build !release
-// +build !release
 
 package main
 

--- a/internal/install/goradd-project/main/main.go
+++ b/internal/install/goradd-project/main/main.go
@@ -3,6 +3,7 @@ package main
 // The spaces in this import block serve to prevent goimports from rearranging the order of the files.
 import (
 	_ "goradd-project/config" // Initialize required variables. This MUST come first.
+	config2 "goradd-project/config"
 
 	// _ "goradd-project/api" // Uncomment this if you are implementing an API (i.e. REST api).
 
@@ -12,6 +13,7 @@ import (
 	"github.com/goradd/goradd/pkg/sys"
 	"goradd-project/web/app"
 	_ "goradd-project/web/form" // Registers forms through init calls.
+	// _ "goradd-project/api" // Uncomment this if you are implementing an API (i.e. REST api).
 	// Custom paths, including additional form directories
 	// _ "mysite"
 )
@@ -48,17 +50,17 @@ func useFlags() {
 	}
 
 	if *port != -1 {
-		config.Port = *port
+		config2.Port = *port
 	}
 
 	if *tlsPort != -1 {
-		config.TLSPort = *tlsPort
+		config2.TLSPort = *tlsPort
 	}
 
 	if *tlsKeyFile != "" {
-		config.TLSKeyFile = *tlsKeyFile
+		config2.TLSKeyFile = *tlsKeyFile
 	}
 	if *tlsCertFile != "" {
-		config.TLSCertFile = *tlsCertFile
+		config2.TLSCertFile = *tlsCertFile
 	}
 }

--- a/internal/install/goradd-project/main/relInclude.go
+++ b/internal/install/goradd-project/main/relInclude.go
@@ -1,5 +1,4 @@
 //go:build release
-// +build release
 
 package main
 

--- a/internal/install/goradd-project/web/app/app.go
+++ b/internal/install/goradd-project/web/app/app.go
@@ -5,8 +5,8 @@ package app
 
 import (
 	"fmt"
-	"github.com/goradd/goradd/pkg/config"
 	"github.com/goradd/goradd/web/app"
+	"goradd-project/config"
 	"log"
 	"net/http"
 )
@@ -17,16 +17,59 @@ type Application struct {
 	// Your own vars, methods and overrides
 }
 
-// MakeApplication creates the application object and related objects.
-// You can potentially read command line params and make other versions of the app for testing purposes.
+// MakeApplication creates the application object and related objects
+// You can potentially read command line params and make other versions of the app for testing purposes
 func MakeApplication() *Application {
 	a := new(Application)
 	a.Init()
 	return a
 }
 
+// Init initializations the application object.
 func (a *Application) Init() {
 	a.Application.Init(a)
+}
+
+// MakeAppServer creates the handler that serves the application.
+//
+// This is typically where you create the middleware stack that divides the server
+// into small pieces that each do one job.
+//
+// The default use the base Application's middleware stack, which itself is quite flexible
+// and has hooks where you can override pieces. Or, you can just replace the whole thing
+// and reimplement it here.
+//
+// See also the Init function where can assign additional handlers to specific paths via
+// the application muxers.
+func (a *Application) MakeAppServer() http.Handler {
+	return a.Application.MakeAppServer()
+}
+
+// RunWebServer launches the main webserver.
+func (a *Application) RunWebServer() (err error) {
+	handler := a.MakeAppServer()
+
+	// If you are directly responding to encrypted requests, launch a server here. Note that you CAN put the app behind
+	// a web server, like Nginx or Apache and let the web server handle the certificate issues.
+
+	if config.TLSPort != 0 {
+		go func() {
+			var addr string
+			if config.TLSPort != 0 {
+				addr = fmt.Sprint(":", config.TLSPort)
+			}
+
+			log.Fatal(app.ListenAndServeTLSWithTimeouts(addr, config.TLSCertFile, config.TLSKeyFile, handler))
+		}()
+	}
+
+	var addr string
+	if config.Port != 0 {
+		addr = fmt.Sprint(":", config.Port)
+	}
+	err = app.ListenAndServeWithTimeouts(addr, handler)
+
+	return
 }
 
 // Uncomment and edit to change the page cache. You can call the embedded Application version first, and then alter it too.
@@ -108,48 +151,6 @@ func (a *Application) SetupDatabaseWatcher() {
 	broadcast.Broadcaster = &broadcast.DefaultBroadcaster{}
 }
 */
-
-// RunWebServer launches the main webserver.
-func (a *Application) RunWebServer() (err error) {
-	handler := a.MakeAppServer()
-
-	// If you are directly responding to encrypted requests, launch a server here. Note that you CAN put the app behind
-	// a web server, like Nginx or Apache and let the web server handle the certificate issues.
-
-	if config.TLSPort != 0 {
-		go func() {
-			var addr string
-			if config.TLSPort != 0 {
-				addr = fmt.Sprint(":", config.TLSPort)
-			}
-
-			log.Fatal(app.ListenAndServeTLSWithTimeouts(addr, config.TLSCertFile, config.TLSKeyFile, handler))
-		}()
-	}
-
-	var addr string
-	if config.Port != 0 {
-		addr = fmt.Sprint(":", config.Port)
-	}
-	err = app.ListenAndServeWithTimeouts(addr, handler)
-
-	return
-}
-
-// MakeAppServer creates the handler that serves the application.
-//
-// This is typically where you create the middleware stack that divides the server
-// into small pieces that each do one job.
-//
-// The default use the base Application's middleware stack, which itself is quite flexible
-// and has hooks where you can override pieces. Or, you can just replace the whole thing
-// and reimplement it here.
-//
-// See also the Init function where can assign additional handlers to specific paths via
-// the application muxers.
-func (a *Application) MakeAppServer() http.Handler {
-	return a.Application.MakeAppServer()
-}
 
 // ServeRequest is the place to serve up any files that have not been handled in any other way, either by a previously
 // declared handler, or by the goradd app server, or the static file server. ServeRequest is only called when all

--- a/pkg/config/app.go
+++ b/pkg/config/app.go
@@ -31,14 +31,3 @@ var AjaxTimeout = 10000
 
 // CacheBusterPrefix is a fragment that is included with cache busted paths.
 var CacheBusterPrefix = "gr."
-
-// Port lets you change the port number that the app will run on, vs. the default
-var Port int = 0
-var TLSPort int = 0 // This will require ssl certificates. The default has this turned off.
-
-// You will need to put in the path to your certfile and keyfile below.
-// The default implementation only uses these for the release build.
-
-// TLSCertFile is the path for the https certificate. By default, it is only used in the release build.
-var TLSCertFile = ""
-var TLSKeyFile = ""

--- a/web/app/server.go
+++ b/web/app/server.go
@@ -18,23 +18,23 @@ func ListenAndServeTLSWithTimeouts(addr, certFile, keyFile string, handler http.
 	// Here we confirm that the CertFile and KeyFile exist. If they don't, ListenAndServeTLS just exit with an open error
 	// and you will not know why.
 	if !sys.PathExists(certFile) {
-		log.Fatalf("TLSCertFile does not exist: %s", config.TLSCertFile)
+		log.Fatalf("TLSCertFile does not exist: %s", certFile)
 	}
 
 	if !sys.PathExists(keyFile) {
-		log.Fatalf("TLSKeyFile does not exist: %s", config.TLSKeyFile)
+		log.Fatalf("TLSKeyFile does not exist: %s", keyFile)
 	}
 
 	// TODO: https://blog.gopheracademy.com/advent-2016/exposing-go-on-the-internet/ recommends keeping track
 	// of open connections using the ConnState hook for debugging purposes.
 
 	server = &http.Server{
-		Addr: addr,
-		ReadTimeout:  config.ReadTimeout,
+		Addr:              addr,
+		ReadTimeout:       config.ReadTimeout,
 		ReadHeaderTimeout: config.ReadHeaderTimeout,
-		WriteTimeout: config.WriteTimeout,
-		IdleTimeout:  config.IdleTimeout,
-		Handler:      handler,
+		WriteTimeout:      config.WriteTimeout,
+		IdleTimeout:       config.IdleTimeout,
+		Handler:           handler,
 	}
 	return server.ListenAndServeTLS(certFile, keyFile)
 }
@@ -50,12 +50,12 @@ func ListenAndServeWithTimeouts(addr string, handler http.Handler) error {
 	// of open connections using the ConnState hook for debugging purposes.
 
 	server = &http.Server{
-		Addr: addr,
-		ReadTimeout:  config.ReadTimeout,
+		Addr:              addr,
+		ReadTimeout:       config.ReadTimeout,
 		ReadHeaderTimeout: config.ReadHeaderTimeout,
-		WriteTimeout: config.WriteTimeout,
-		IdleTimeout:  config.IdleTimeout,
-		Handler:      handler,
+		WriteTimeout:      config.WriteTimeout,
+		IdleTimeout:       config.IdleTimeout,
+		Handler:           handler,
 	}
 	return server.ListenAndServe()
 }


### PR DESCRIPTION
Moving some globals out of the framework and into the app space so they are easier to customize.

This is a breaking change and will require updates to the config variables in existing projects.